### PR TITLE
[codex] resolve helpdesk issues 15-20

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+**/bin
+**/obj
+**/.DS_Store
+output
+backups

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env for docker-compose deployments.
+JWT_SIGNING_KEY=change-me-with-32-characters-minimum
+OPENAI_API_KEY=
+AI_ENABLED=true

--- a/Helpdesk-Light/03-KPI-Definitions.md
+++ b/Helpdesk-Light/03-KPI-Definitions.md
@@ -1,0 +1,56 @@
+# Helpdesk-Light KPI Definitions
+
+This document defines the dashboard metrics exposed by `GET /api/v1/analytics/dashboard`.
+
+## Filters and Scope
+
+- `customerId`: optional for MSP admin; ignored for non-admin users (tenant scope is forced to caller's customer).
+- `fromUtc` / `toUtc`: optional UTC range. Default is last 30 days when omitted.
+
+## Operational KPIs
+
+- **Total Ticket Volume**
+  - Count of tickets where `Ticket.CreatedUtc` is inside the selected time range.
+
+- **Open Ticket Count**
+  - Count of ranged tickets where `Ticket.Status` is not `Resolved` and not `Closed`.
+
+- **Open Tickets By Priority**
+  - Group of open ranged tickets by `Ticket.Priority`.
+
+- **Channel Split**
+  - Group of ranged tickets by `Ticket.Channel` (`Web`, `Email`).
+
+- **Average First Response Minutes**
+  - For each ranged ticket, measure minutes between `Ticket.CreatedUtc` and first message by `Technician` or `Agent`.
+  - Report average across tickets that have at least one technician/agent response.
+
+- **Average Resolution Minutes**
+  - For tickets with `Ticket.ResolvedUtc` inside range, measure minutes between `Ticket.CreatedUtc` and `Ticket.ResolvedUtc`.
+  - Report average across resolved tickets in range.
+
+## AI KPIs
+
+- **Total AI Suggestions**
+  - Count of `TicketAiSuggestion` rows where `CreatedUtc` is inside range and ticket is in scope.
+
+- **Accepted AI Suggestions**
+  - Count of suggestions where status is `Approved` or `AutoSent`.
+
+- **Suggestion Acceptance Rate**
+  - `AcceptedAiSuggestions / TotalAiSuggestions`.
+
+- **Auto Response Count**
+  - Count of suggestions where status is `AutoSent`.
+
+- **Auto Response Rate**
+  - `AutoResponseCount / TotalAiSuggestions`.
+
+- **AI Generated Article Count**
+  - Count of `KnowledgeArticle` where `AiGenerated = true` and `CreatedUtc` is in range and tenant scope.
+
+- **Published AI Generated Article Count**
+  - Count of scoped AI-generated articles where `PublishedUtc` is not null.
+
+- **Article Draft Acceptance Rate**
+  - `PublishedAiGeneratedArticleCount / AiGeneratedArticleCount`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ dotnet build Helpdesk.Light.slnx -warnaserror
 dotnet test Helpdesk.Light.slnx
 ```
 
+CI-ready test command:
+
+```bash
+dotnet test Helpdesk.Light.slnx --configuration Release --no-build
+```
+
 ## Run API
 
 ```bash
@@ -54,3 +60,26 @@ The API base URL is configured in `src/Helpdesk.Light.Web/wwwroot/appsettings.js
 ```bash
 dotnet run --project src/Helpdesk.Light.Worker
 ```
+
+## Health, Analytics, and Operations Endpoints
+
+- `GET /health/live` (anonymous)
+- `GET /health/ready` (anonymous)
+- `GET /api/v1/analytics/dashboard` (authenticated, tenant-scoped)
+- `GET /api/v1/ops/metrics` (MSP admin)
+- `GET /api/v1/ops/dead-letters` (MSP admin)
+- `POST /api/v1/email/outbound/retry-dead-letter` (MSP admin)
+
+KPI definitions are documented in `Helpdesk-Light/03-KPI-Definitions.md`.
+
+## Backup and Restore
+
+- Backup: `./scripts/backup-helpdesk.sh`
+- Restore: `./scripts/restore-helpdesk.sh`
+- Runbook: `docs/operations-runbook.md`
+
+## Deployment
+
+- Deployment docs: `docs/deployment.md`
+- Config templates: `deploy/`
+- Container assets: `docker/` + `docker-compose.yml`

--- a/deploy/appsettings.Api.Production.template.json
+++ b/deploy/appsettings.Api.Production.template.json
@@ -1,0 +1,44 @@
+{
+  "ConnectionStrings": {
+    "Helpdesk": "Data Source=/data/helpdesk-light.db"
+  },
+  "Jwt": {
+    "Issuer": "Helpdesk-Light",
+    "Audience": "Helpdesk-Light-Clients",
+    "SigningKey": "<set-from-secret-store>",
+    "ExpiryMinutes": 60
+  },
+  "Cors": {
+    "Frontend": {
+      "AllowedOrigins": [
+        "https://helpdesk.example.com"
+      ]
+    }
+  },
+  "Attachments": {
+    "RootPath": "/data/attachments",
+    "MaxSizeBytes": 10485760,
+    "AllowedContentTypes": [
+      "application/pdf",
+      "image/png",
+      "image/jpeg",
+      "text/plain",
+      "application/zip"
+    ]
+  },
+  "Email": {
+    "MaxRetryCount": 3
+  },
+  "Ai": {
+    "ModelId": "gpt-5.2",
+    "EnableAi": true,
+    "AutoRunOnCreateOrUpdate": true,
+    "OpenAIApiKey": "<set-from-secret-store>"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/deploy/appsettings.Web.Production.template.json
+++ b/deploy/appsettings.Web.Production.template.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "https://api.helpdesk.example.com/"
+}

--- a/deploy/appsettings.Worker.Production.template.json
+++ b/deploy/appsettings.Worker.Production.template.json
@@ -1,0 +1,30 @@
+{
+  "ConnectionStrings": {
+    "Helpdesk": "Data Source=/data/helpdesk-light.db"
+  },
+  "Attachments": {
+    "RootPath": "/data/attachments",
+    "MaxSizeBytes": 10485760,
+    "AllowedContentTypes": [
+      "application/pdf",
+      "image/png",
+      "image/jpeg",
+      "text/plain",
+      "application/zip"
+    ]
+  },
+  "Email": {
+    "MaxRetryCount": 3
+  },
+  "Ai": {
+    "ModelId": "gpt-5.2",
+    "EnableAi": true,
+    "AutoRunOnCreateOrUpdate": true,
+    "OpenAIApiKey": "<set-from-secret-store>"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  }
+}

--- a/deploy/nginx/helpdesk-web.conf
+++ b/deploy/nginx/helpdesk-web.conf
@@ -1,0 +1,16 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:json|wasm|js|css|png|jpg|jpeg|gif|svg|ico)$ {
+        add_header Cache-Control "public, max-age=300";
+        try_files $uri =404;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.api
+    container_name: helpdesk-light-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Helpdesk: Data Source=/data/helpdesk-light.db
+      Attachments__RootPath: /data/attachments
+      Jwt__Issuer: Helpdesk-Light
+      Jwt__Audience: Helpdesk-Light-Clients
+      Jwt__SigningKey: ${JWT_SIGNING_KEY:-change-me-with-32-characters-minimum}
+      Email__MaxRetryCount: 3
+      Ai__ModelId: gpt-5.2
+      Ai__EnableAi: ${AI_ENABLED:-true}
+      Ai__AutoRunOnCreateOrUpdate: true
+      Ai__OpenAIApiKey: ${OPENAI_API_KEY:-}
+      Cors__Frontend__AllowedOrigins__0: http://localhost:8082
+    ports:
+      - "8080:8080"
+    volumes:
+      - helpdesk_data:/data
+
+  worker:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
+    container_name: helpdesk-light-worker
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Helpdesk: Data Source=/data/helpdesk-light.db
+      Attachments__RootPath: /data/attachments
+      Email__MaxRetryCount: 3
+      Ai__ModelId: gpt-5.2
+      Ai__EnableAi: ${AI_ENABLED:-true}
+      Ai__AutoRunOnCreateOrUpdate: true
+      Ai__OpenAIApiKey: ${OPENAI_API_KEY:-}
+    depends_on:
+      - api
+    volumes:
+      - helpdesk_data:/data
+
+  web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.web
+    container_name: helpdesk-light-web
+    ports:
+      - "8082:8080"
+    depends_on:
+      - api
+
+volumes:
+  helpdesk_data:

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore Helpdesk.Light.slnx
+RUN dotnet publish src/Helpdesk.Light.Api/Helpdesk.Light.Api.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Helpdesk.Light.Api.dll"]

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore src/Helpdesk.Light.Web/Helpdesk.Light.Web.csproj
+RUN dotnet publish src/Helpdesk.Light.Web/Helpdesk.Light.Web.csproj -c Release -o /app/publish --no-restore
+
+FROM nginx:1.27-alpine AS runtime
+COPY deploy/nginx/helpdesk-web.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore Helpdesk.Light.slnx
+RUN dotnet publish src/Helpdesk.Light.Worker/Helpdesk.Light.Worker.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Helpdesk.Light.Worker.dll"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,84 @@
+# Deployment and Environment Configuration
+
+## 1. Components
+
+The platform deploys three services:
+
+- API (`src/Helpdesk.Light.Api`)
+- Worker (`src/Helpdesk.Light.Worker`)
+- Web (`src/Helpdesk.Light.Web`, static Blazor WebAssembly)
+
+## 2. Configuration Templates
+
+Use these templates as production baselines:
+
+- `deploy/appsettings.Api.Production.template.json`
+- `deploy/appsettings.Worker.Production.template.json`
+- `deploy/appsettings.Web.Production.template.json`
+
+## 3. Secrets Strategy
+
+Do not commit real secrets.
+
+Inject secrets using your platform secret store or environment variables:
+
+- `Jwt__SigningKey`
+- `Ai__OpenAIApiKey`
+- any real SMTP or mail adapter credentials (if not using console transport)
+
+For local container deployment, copy `.env.example` to `.env` and set values.
+
+## 4. Build Artifacts
+
+Container build files are included:
+
+- `docker/Dockerfile.api`
+- `docker/Dockerfile.worker`
+- `docker/Dockerfile.web`
+- `docker-compose.yml`
+
+Build images:
+
+```bash
+./scripts/build-images.sh local
+```
+
+## 5. Start in Development
+
+```bash
+dotnet restore Helpdesk.Light.slnx
+dotnet build Helpdesk.Light.slnx -warnaserror
+dotnet run --project src/Helpdesk.Light.Api
+dotnet run --project src/Helpdesk.Light.Worker
+dotnet run --project src/Helpdesk.Light.Web
+```
+
+## 6. Start with Docker Compose
+
+```bash
+cp .env.example .env
+# edit .env with secure values
+
+docker compose up --build
+```
+
+Endpoints:
+
+- API: `http://localhost:8080`
+- Web: `http://localhost:8082`
+
+## 7. Startup Verification
+
+After startup, verify:
+
+- `GET /health/live`
+- `GET /health/ready`
+- admin login and seeded user auth
+- ticket creation from web and email pathways
+- worker dispatch loop running (check `GET /api/v1/ops/metrics` as admin)
+
+## 8. Reproducibility Notes
+
+- Containers build from pinned .NET 10 SDK/runtime images.
+- Configuration is externalized with templates + environment variable overrides.
+- Backup and restore scripts are in `scripts/` and operational procedures are in `docs/operations-runbook.md`.

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -1,0 +1,107 @@
+# Helpdesk-Light Operations Runbook
+
+## 1. Scope
+
+This runbook covers:
+
+- SQLite and attachment backup/restore
+- Background email reliability (retry + dead-letter)
+- Operational checks for API, worker, mail adapter, and AI provider
+
+## 2. Backup Strategy
+
+### Frequency
+
+- Production: hourly incremental filesystem snapshot + daily backup archive.
+- Non-production: daily backup archive.
+
+### What to back up
+
+- SQLite database file (`helpdesk-light.db`)
+- Attachment directory (`storage/attachments`)
+
+### Backup command
+
+```bash
+./scripts/backup-helpdesk.sh \
+  --db ./helpdesk-light.db \
+  --attachments ./storage/attachments \
+  --out ./backups
+```
+
+### Validation included
+
+- `PRAGMA integrity_check` runs before and after DB copy.
+- SHA-256 checksum file is generated for DB, metadata, and attachment files.
+
+## 3. Restore Procedure
+
+### Preconditions
+
+- Stop API and Worker services.
+- Confirm archive path and restore target paths.
+
+### Restore command
+
+```bash
+./scripts/restore-helpdesk.sh \
+  --archive ./backups/helpdesk-backup-<timestamp>.tar.gz \
+  --db ./helpdesk-light.db \
+  --attachments ./storage/attachments
+```
+
+### Validation included
+
+- Optional checksum verification from `checksums.sha256`.
+- `PRAGMA integrity_check` runs on extracted DB and restored DB.
+- Existing DB and attachment directories are preserved with `.pre-restore-<timestamp>` suffix.
+
+## 4. Background Job Reliability
+
+### Retry and dead-letter rules
+
+- Outbound messages are retried up to `Email:MaxRetryCount`.
+- Messages that exceed retry threshold move to `DeadLetter` status.
+- Dead letters are visible via `GET /api/v1/ops/dead-letters`.
+
+### Retrying dead letters
+
+```bash
+curl -X POST "http://localhost:5283/api/v1/email/outbound/retry-dead-letter?take=50" \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+## 5. Health and Diagnostics
+
+### Health endpoints
+
+- Liveness: `GET /health/live`
+- Readiness: `GET /health/ready`
+
+Readiness includes checks for:
+
+- SQLite connectivity
+- Mail adapter configuration
+- AI provider configuration
+
+### Runtime metrics endpoint
+
+- `GET /api/v1/ops/metrics`
+
+Includes:
+
+- API request count, errors, and average latency
+- worker queue depth
+- email outcome counters
+- AI duration and failure counters
+- recent worker failures
+
+## 6. Rollback Guidance
+
+If a deployment fails:
+
+1. Stop services.
+2. Restore latest verified archive with `restore-helpdesk.sh`.
+3. Validate `/health/ready` and login flow.
+4. Replay dead-letter emails if required.
+5. Document incident timeline and root cause in postmortem notes.

--- a/scripts/backup-helpdesk.sh
+++ b/scripts/backup-helpdesk.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--db PATH] [--attachments PATH] [--out PATH]
+
+Creates a timestamped backup archive containing:
+- SQLite database file
+- Attachments directory
+- metadata and checksums
+
+Defaults:
+  --db           ./helpdesk-light.db
+  --attachments  ./storage/attachments
+  --out          ./backups
+USAGE
+}
+
+DB_PATH="./helpdesk-light.db"
+ATTACHMENTS_PATH="./storage/attachments"
+OUT_DIR="./backups"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db)
+      DB_PATH="$2"
+      shift 2
+      ;;
+    --attachments)
+      ATTACHMENTS_PATH="$2"
+      shift 2
+      ;;
+    --out)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "Database file not found: $DB_PATH" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required for integrity checks." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+WORK_DIR="$(mktemp -d)"
+PAYLOAD_DIR="$WORK_DIR/helpdesk-backup-$TS"
+ARCHIVE_PATH="$OUT_DIR/helpdesk-backup-$TS.tar.gz"
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$PAYLOAD_DIR"
+
+INTEGRITY_RESULT="$(sqlite3 "$DB_PATH" 'PRAGMA integrity_check;')"
+if [[ "$INTEGRITY_RESULT" != "ok" ]]; then
+  echo "SQLite integrity check failed before backup: $INTEGRITY_RESULT" >&2
+  exit 1
+fi
+
+cp "$DB_PATH" "$PAYLOAD_DIR/helpdesk.db"
+
+if [[ -d "$ATTACHMENTS_PATH" ]]; then
+  cp -R "$ATTACHMENTS_PATH" "$PAYLOAD_DIR/attachments"
+else
+  mkdir -p "$PAYLOAD_DIR/attachments"
+fi
+
+cat > "$PAYLOAD_DIR/metadata.txt" <<META
+created_utc=$TS
+source_db=$DB_PATH
+source_attachments=$ATTACHMENTS_PATH
+META
+
+(
+  cd "$PAYLOAD_DIR"
+  shasum -a 256 helpdesk.db metadata.txt > checksums.sha256
+  if [[ -d attachments ]]; then
+    find attachments -type f -print0 | sort -z | xargs -0 shasum -a 256 >> checksums.sha256 || true
+  fi
+)
+
+POST_COPY_INTEGRITY="$(sqlite3 "$PAYLOAD_DIR/helpdesk.db" 'PRAGMA integrity_check;')"
+if [[ "$POST_COPY_INTEGRITY" != "ok" ]]; then
+  echo "SQLite integrity check failed on backup copy: $POST_COPY_INTEGRITY" >&2
+  exit 1
+fi
+
+tar -czf "$ARCHIVE_PATH" -C "$WORK_DIR" "helpdesk-backup-$TS"
+
+echo "Backup created: $ARCHIVE_PATH"

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG="${1:-local}"
+
+docker build -f docker/Dockerfile.api -t helpdesk-light-api:${TAG} .
+docker build -f docker/Dockerfile.worker -t helpdesk-light-worker:${TAG} .
+docker build -f docker/Dockerfile.web -t helpdesk-light-web:${TAG} .
+
+echo "Built images with tag: ${TAG}"

--- a/scripts/restore-helpdesk.sh
+++ b/scripts/restore-helpdesk.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") --archive PATH [--db PATH] [--attachments PATH]
+
+Restores a backup created by backup-helpdesk.sh.
+Stops are not automatic: stop API/Worker before restoring.
+
+Defaults:
+  --db           ./helpdesk-light.db
+  --attachments  ./storage/attachments
+USAGE
+}
+
+ARCHIVE_PATH=""
+DB_PATH="./helpdesk-light.db"
+ATTACHMENTS_PATH="./storage/attachments"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive)
+      ARCHIVE_PATH="$2"
+      shift 2
+      ;;
+    --db)
+      DB_PATH="$2"
+      shift 2
+      ;;
+    --attachments)
+      ATTACHMENTS_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$ARCHIVE_PATH" ]]; then
+  echo "--archive is required." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$ARCHIVE_PATH" ]]; then
+  echo "Archive not found: $ARCHIVE_PATH" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required for integrity checks." >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+tar -xzf "$ARCHIVE_PATH" -C "$WORK_DIR"
+BACKUP_ROOT="$(find "$WORK_DIR" -maxdepth 1 -type d -name 'helpdesk-backup-*' | head -n 1)"
+
+if [[ -z "$BACKUP_ROOT" ]]; then
+  echo "Archive structure invalid; expected helpdesk-backup-* directory." >&2
+  exit 1
+fi
+
+if [[ ! -f "$BACKUP_ROOT/helpdesk.db" ]]; then
+  echo "Backup is missing helpdesk.db" >&2
+  exit 1
+fi
+
+if [[ -f "$BACKUP_ROOT/checksums.sha256" ]]; then
+  (
+    cd "$BACKUP_ROOT"
+    shasum -a 256 --check checksums.sha256
+  )
+fi
+
+INTEGRITY_RESULT="$(sqlite3 "$BACKUP_ROOT/helpdesk.db" 'PRAGMA integrity_check;')"
+if [[ "$INTEGRITY_RESULT" != "ok" ]]; then
+  echo "SQLite integrity check failed in archive: $INTEGRITY_RESULT" >&2
+  exit 1
+fi
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -f "$DB_PATH" ]]; then
+  cp "$DB_PATH" "$DB_PATH.pre-restore-$TS"
+fi
+
+if [[ -d "$ATTACHMENTS_PATH" ]]; then
+  mv "$ATTACHMENTS_PATH" "$ATTACHMENTS_PATH.pre-restore-$TS"
+fi
+
+mkdir -p "$(dirname "$DB_PATH")"
+mkdir -p "$(dirname "$ATTACHMENTS_PATH")"
+
+cp "$BACKUP_ROOT/helpdesk.db" "$DB_PATH"
+if [[ -d "$BACKUP_ROOT/attachments" ]]; then
+  cp -R "$BACKUP_ROOT/attachments" "$ATTACHMENTS_PATH"
+else
+  mkdir -p "$ATTACHMENTS_PATH"
+fi
+
+RESTORED_INTEGRITY="$(sqlite3 "$DB_PATH" 'PRAGMA integrity_check;')"
+if [[ "$RESTORED_INTEGRITY" != "ok" ]]; then
+  echo "SQLite integrity check failed after restore: $RESTORED_INTEGRITY" >&2
+  exit 1
+fi
+
+echo "Restore completed successfully."
+echo "Database: $DB_PATH"
+echo "Attachments: $ATTACHMENTS_PATH"

--- a/src/Helpdesk.Light.Api/Controllers/AnalyticsController.cs
+++ b/src/Helpdesk.Light.Api/Controllers/AnalyticsController.cs
@@ -1,0 +1,41 @@
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Application.Errors;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Helpdesk.Light.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/analytics")]
+[Authorize]
+public sealed class AnalyticsController(IAnalyticsService analyticsService) : ControllerBase
+{
+    [HttpGet("dashboard")]
+    [ProducesResponseType<AnalyticsDashboardDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<AnalyticsDashboardDto>> GetDashboard(
+        [FromQuery] Guid? customerId,
+        [FromQuery] DateTime? fromUtc,
+        [FromQuery] DateTime? toUtc,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            AnalyticsDashboardDto dashboard = await analyticsService.GetDashboardAsync(
+                new AnalyticsDashboardRequest(customerId, fromUtc, toUtc),
+                cancellationToken);
+
+            return Ok(dashboard);
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
+}

--- a/src/Helpdesk.Light.Api/Controllers/KnowledgeBaseController.cs
+++ b/src/Helpdesk.Light.Api/Controllers/KnowledgeBaseController.cs
@@ -1,0 +1,178 @@
+using Helpdesk.Light.Application.Abstractions.Ai;
+using Helpdesk.Light.Application.Contracts.Ai;
+using Helpdesk.Light.Application.Errors;
+using Helpdesk.Light.Domain.Security;
+using Helpdesk.Light.Domain.Ai;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Helpdesk.Light.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/knowledge/articles")]
+[Authorize(Roles = $"{RoleNames.Technician},{RoleNames.MspAdmin}")]
+public sealed class KnowledgeBaseController(IKnowledgeBaseService knowledgeBaseService) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType<IReadOnlyList<KnowledgeArticleSummaryDto>>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<KnowledgeArticleSummaryDto>>> List(
+        [FromQuery] string? search,
+        [FromQuery] KnowledgeArticleStatus? status,
+        [FromQuery] Guid? customerId,
+        [FromQuery] int take,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<KnowledgeArticleSummaryDto> articles = await knowledgeBaseService.ListAsync(
+            new KnowledgeArticleListRequest(search, status, customerId, take <= 0 ? 100 : take),
+            cancellationToken);
+
+        return Ok(articles);
+    }
+
+    [HttpGet("{articleId:guid}")]
+    [ProducesResponseType<KnowledgeArticleDetailDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<KnowledgeArticleDetailDto>> Get(Guid articleId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            KnowledgeArticleDetailDto? article = await knowledgeBaseService.GetAsync(articleId, cancellationToken);
+            return article is null ? NotFound() : Ok(article);
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost]
+    [ProducesResponseType<KnowledgeArticleDetailDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<KnowledgeArticleDetailDto>> CreateDraft(
+        [FromBody] KnowledgeArticleDraftCreateRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            KnowledgeArticleDetailDto created = await knowledgeBaseService.CreateDraftAsync(request, cancellationToken);
+            return Created($"/api/v1/knowledge/articles/{created.Id}", created);
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
+
+    [HttpPut("{articleId:guid}")]
+    [ProducesResponseType<KnowledgeArticleDetailDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<KnowledgeArticleDetailDto>> UpdateDraft(
+        Guid articleId,
+        [FromBody] KnowledgeArticleDraftUpdateRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            KnowledgeArticleDetailDto updated = await knowledgeBaseService.UpdateDraftAsync(articleId, request, cancellationToken);
+            return Ok(updated);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
+
+    [HttpPost("from-ticket/{ticketId:guid}")]
+    [ProducesResponseType<KnowledgeArticleDetailDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<KnowledgeArticleDetailDto>> GenerateFromTicket(Guid ticketId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            KnowledgeArticleDetailDto created = await knowledgeBaseService.GenerateDraftFromTicketAsync(ticketId, cancellationToken);
+            return Created($"/api/v1/knowledge/articles/{created.Id}", created);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
+
+    [HttpPost("{articleId:guid}/publish")]
+    [ProducesResponseType<KnowledgeArticleDetailDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<KnowledgeArticleDetailDto>> Publish(Guid articleId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            KnowledgeArticleDetailDto published = await knowledgeBaseService.PublishAsync(articleId, cancellationToken);
+            return Ok(published);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
+
+    [HttpPost("{articleId:guid}/archive")]
+    [ProducesResponseType<KnowledgeArticleDetailDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<KnowledgeArticleDetailDto>> Archive(Guid articleId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            KnowledgeArticleDetailDto archived = await knowledgeBaseService.ArchiveAsync(articleId, cancellationToken);
+            return Ok(archived);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (TenantAccessDeniedException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
+}

--- a/src/Helpdesk.Light.Api/Controllers/OperationsController.cs
+++ b/src/Helpdesk.Light.Api/Controllers/OperationsController.cs
@@ -1,0 +1,51 @@
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Domain.Email;
+using Helpdesk.Light.Domain.Security;
+using Helpdesk.Light.Infrastructure.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Helpdesk.Light.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/ops")]
+[Authorize(Roles = RoleNames.MspAdmin)]
+public sealed class OperationsController(
+    IRuntimeMetricsRecorder runtimeMetricsRecorder,
+    HelpdeskDbContext dbContext) : ControllerBase
+{
+    [HttpGet("metrics")]
+    [ProducesResponseType<OperationsMetricsDto>(StatusCodes.Status200OK)]
+    public ActionResult<OperationsMetricsDto> GetMetrics()
+    {
+        return Ok(runtimeMetricsRecorder.GetSnapshot());
+    }
+
+    [HttpGet("dead-letters")]
+    [ProducesResponseType<IReadOnlyList<DeadLetterMessageDto>>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<DeadLetterMessageDto>>> ListDeadLetters([FromQuery] int take, CancellationToken cancellationToken)
+    {
+        int boundedTake = take <= 0 ? 50 : Math.Clamp(take, 1, 500);
+
+        List<DeadLetterMessageDto> messages = await dbContext.OutboundEmailMessages
+            .AsNoTracking()
+            .Where(item => item.Status == OutboundEmailStatus.DeadLetter)
+            .OrderByDescending(item => item.DeadLetteredUtc ?? item.CreatedUtc)
+            .Take(boundedTake)
+            .Select(item => new DeadLetterMessageDto(
+                item.Id,
+                item.TicketId,
+                item.CustomerId,
+                item.ToAddress,
+                item.Subject,
+                item.AttemptCount,
+                item.LastError,
+                item.CreatedUtc,
+                item.DeadLetteredUtc))
+            .ToListAsync(cancellationToken);
+
+        return Ok(messages);
+    }
+}

--- a/src/Helpdesk.Light.Api/Controllers/OutboundEmailController.cs
+++ b/src/Helpdesk.Light.Api/Controllers/OutboundEmailController.cs
@@ -32,4 +32,12 @@ public sealed class OutboundEmailController(
         await outboundEmailService.DispatchPendingAsync(cancellationToken);
         return NoContent();
     }
+
+    [HttpPost("retry-dead-letter")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<object>> RetryDeadLetter([FromQuery] int take, CancellationToken cancellationToken)
+    {
+        int retried = await outboundEmailService.RetryDeadLettersAsync(take <= 0 ? 50 : take, cancellationToken);
+        return Ok(new { retried });
+    }
 }

--- a/src/Helpdesk.Light.Api/Observability/CorrelationIdMiddleware.cs
+++ b/src/Helpdesk.Light.Api/Observability/CorrelationIdMiddleware.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using Helpdesk.Light.Application.Abstractions;
+
+namespace Helpdesk.Light.Api.Observability;
+
+public sealed class CorrelationIdMiddleware(
+    RequestDelegate next,
+    ILogger<CorrelationIdMiddleware> logger)
+{
+    public const string HeaderName = "X-Correlation-ID";
+
+    public async Task InvokeAsync(HttpContext context, IRuntimeMetricsRecorder runtimeMetrics)
+    {
+        string correlationId = ResolveCorrelationId(context);
+        context.TraceIdentifier = correlationId;
+        context.Response.Headers[HeaderName] = correlationId;
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        using IDisposable? scope = logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["CorrelationId"] = correlationId
+        });
+
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            int statusCode = context.Response.StatusCode;
+            runtimeMetrics.RecordApiRequest(statusCode, stopwatch.Elapsed.TotalMilliseconds);
+
+            logger.LogInformation(
+                "HTTP {Method} {Path} responded {StatusCode} in {DurationMs:N1}ms",
+                context.Request.Method,
+                context.Request.Path.Value ?? "/",
+                statusCode,
+                stopwatch.Elapsed.TotalMilliseconds);
+        }
+    }
+
+    private static string ResolveCorrelationId(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(HeaderName, out var values))
+        {
+            string? candidate = values.FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(candidate))
+            {
+                return candidate.Trim();
+            }
+        }
+
+        return Guid.NewGuid().ToString("N");
+    }
+}

--- a/src/Helpdesk.Light.Application/Abstractions/Ai/IKnowledgeBaseService.cs
+++ b/src/Helpdesk.Light.Application/Abstractions/Ai/IKnowledgeBaseService.cs
@@ -1,0 +1,20 @@
+using Helpdesk.Light.Application.Contracts.Ai;
+
+namespace Helpdesk.Light.Application.Abstractions.Ai;
+
+public interface IKnowledgeBaseService
+{
+    Task<IReadOnlyList<KnowledgeArticleSummaryDto>> ListAsync(KnowledgeArticleListRequest request, CancellationToken cancellationToken = default);
+
+    Task<KnowledgeArticleDetailDto?> GetAsync(Guid articleId, CancellationToken cancellationToken = default);
+
+    Task<KnowledgeArticleDetailDto> CreateDraftAsync(KnowledgeArticleDraftCreateRequest request, CancellationToken cancellationToken = default);
+
+    Task<KnowledgeArticleDetailDto> UpdateDraftAsync(Guid articleId, KnowledgeArticleDraftUpdateRequest request, CancellationToken cancellationToken = default);
+
+    Task<KnowledgeArticleDetailDto> GenerateDraftFromTicketAsync(Guid ticketId, CancellationToken cancellationToken = default);
+
+    Task<KnowledgeArticleDetailDto> PublishAsync(Guid articleId, CancellationToken cancellationToken = default);
+
+    Task<KnowledgeArticleDetailDto> ArchiveAsync(Guid articleId, CancellationToken cancellationToken = default);
+}

--- a/src/Helpdesk.Light.Application/Abstractions/Email/IOutboundEmailService.cs
+++ b/src/Helpdesk.Light.Application/Abstractions/Email/IOutboundEmailService.cs
@@ -8,5 +8,7 @@ public interface IOutboundEmailService
 
     Task DispatchPendingAsync(CancellationToken cancellationToken = default);
 
+    Task<int> RetryDeadLettersAsync(int take = 50, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<OutboundEmailDto>> ListAsync(Guid? customerId, CancellationToken cancellationToken = default);
 }

--- a/src/Helpdesk.Light.Application/Abstractions/IAnalyticsService.cs
+++ b/src/Helpdesk.Light.Application/Abstractions/IAnalyticsService.cs
@@ -1,0 +1,8 @@
+using Helpdesk.Light.Application.Contracts;
+
+namespace Helpdesk.Light.Application.Abstractions;
+
+public interface IAnalyticsService
+{
+    Task<AnalyticsDashboardDto> GetDashboardAsync(AnalyticsDashboardRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Helpdesk.Light.Application/Abstractions/IRuntimeMetricsRecorder.cs
+++ b/src/Helpdesk.Light.Application/Abstractions/IRuntimeMetricsRecorder.cs
@@ -1,0 +1,22 @@
+using Helpdesk.Light.Application.Contracts;
+
+namespace Helpdesk.Light.Application.Abstractions;
+
+public interface IRuntimeMetricsRecorder
+{
+    void RecordApiRequest(int statusCode, double latencyMs);
+
+    void SetWorkerQueueDepth(int depth);
+
+    void RecordEmailSent();
+
+    void RecordEmailFailed();
+
+    void RecordEmailDeadLetter();
+
+    void RecordAiRun(double durationMs, bool success);
+
+    void RecordWorkerFailure(string worker, string error);
+
+    OperationsMetricsDto GetSnapshot();
+}

--- a/src/Helpdesk.Light.Application/Contracts/Ai/AiContracts.cs
+++ b/src/Helpdesk.Light.Application/Contracts/Ai/AiContracts.cs
@@ -17,3 +17,47 @@ public sealed record AiRunResult(
 public sealed record TicketAiApprovalRequest(string? EditedResponse);
 
 public sealed record CustomerAiPolicyUpdateRequest(AiPolicyMode Mode, double AutoRespondMinConfidence);
+
+public sealed record KnowledgeArticleListRequest(
+    string? Search,
+    KnowledgeArticleStatus? Status,
+    Guid? CustomerId,
+    int Take = 100);
+
+public sealed record KnowledgeArticleDraftCreateRequest(
+    Guid? CustomerId,
+    Guid? SourceTicketId,
+    string Title,
+    string ContentMarkdown,
+    bool AiGenerated);
+
+public sealed record KnowledgeArticleDraftUpdateRequest(
+    string Title,
+    string ContentMarkdown);
+
+public sealed record KnowledgeArticleSummaryDto(
+    Guid Id,
+    Guid? CustomerId,
+    Guid? SourceTicketId,
+    string Title,
+    KnowledgeArticleStatus Status,
+    int Version,
+    bool AiGenerated,
+    DateTime UpdatedUtc);
+
+public sealed record KnowledgeArticleDetailDto(
+    Guid Id,
+    Guid? CustomerId,
+    Guid? SourceTicketId,
+    string Title,
+    string ContentMarkdown,
+    KnowledgeArticleStatus Status,
+    int Version,
+    bool AiGenerated,
+    Guid? LastEditedByUserId,
+    Guid? PublishedByUserId,
+    Guid? ArchivedByUserId,
+    DateTime CreatedUtc,
+    DateTime UpdatedUtc,
+    DateTime? PublishedUtc,
+    DateTime? ArchivedUtc);

--- a/src/Helpdesk.Light.Application/Contracts/AnalyticsContracts.cs
+++ b/src/Helpdesk.Light.Application/Contracts/AnalyticsContracts.cs
@@ -1,0 +1,24 @@
+namespace Helpdesk.Light.Application.Contracts;
+
+public sealed record AnalyticsDashboardRequest(
+    Guid? CustomerId,
+    DateTime? FromUtc,
+    DateTime? ToUtc);
+
+public sealed record AnalyticsDashboardDto(
+    DateTime RangeStartUtc,
+    DateTime RangeEndUtc,
+    int TotalTicketVolume,
+    int OpenTicketCount,
+    double? AverageFirstResponseMinutes,
+    double? AverageResolutionMinutes,
+    IReadOnlyDictionary<string, int> OpenTicketsByPriority,
+    IReadOnlyDictionary<string, int> ChannelSplit,
+    int TotalAiSuggestions,
+    int AcceptedAiSuggestions,
+    int AutoResponseCount,
+    int AiGeneratedArticleCount,
+    int PublishedAiGeneratedArticleCount,
+    double SuggestionAcceptanceRate,
+    double AutoResponseRate,
+    double ArticleDraftAcceptanceRate);

--- a/src/Helpdesk.Light.Application/Contracts/Email/EmailContracts.cs
+++ b/src/Helpdesk.Light.Application/Contracts/Email/EmailContracts.cs
@@ -24,4 +24,5 @@ public sealed record OutboundEmailDto(
     int AttemptCount,
     string? LastError,
     DateTime CreatedUtc,
-    DateTime? SentUtc);
+    DateTime? SentUtc,
+    DateTime? DeadLetteredUtc);

--- a/src/Helpdesk.Light.Application/Contracts/OperationsContracts.cs
+++ b/src/Helpdesk.Light.Application/Contracts/OperationsContracts.cs
@@ -1,0 +1,28 @@
+namespace Helpdesk.Light.Application.Contracts;
+
+public sealed record OperationsMetricsDto(
+    DateTime GeneratedUtc,
+    long ApiRequestCount,
+    long ApiErrorCount,
+    double AverageApiLatencyMs,
+    int WorkerQueueDepth,
+    long EmailSentCount,
+    long EmailFailedCount,
+    long EmailDeadLetterCount,
+    long AiRunCount,
+    long AiRunFailureCount,
+    double AverageAiDurationMs,
+    IReadOnlyList<WorkerFailureDto> RecentWorkerFailures);
+
+public sealed record WorkerFailureDto(DateTime CreatedUtc, string Worker, string Error);
+
+public sealed record DeadLetterMessageDto(
+    Guid Id,
+    Guid? TicketId,
+    Guid CustomerId,
+    string ToAddress,
+    string Subject,
+    int AttemptCount,
+    string? LastError,
+    DateTime CreatedUtc,
+    DateTime? DeadLetteredUtc);

--- a/src/Helpdesk.Light.Domain/Ai/KnowledgeArticle.cs
+++ b/src/Helpdesk.Light.Domain/Ai/KnowledgeArticle.cs
@@ -6,20 +6,30 @@ public sealed class KnowledgeArticle
     {
         Title = string.Empty;
         ContentMarkdown = string.Empty;
-        Status = string.Empty;
     }
 
-    public KnowledgeArticle(Guid id, Guid? customerId, string title, string contentMarkdown, string status, DateTime createdUtc)
+    public KnowledgeArticle(
+        Guid id,
+        Guid? customerId,
+        Guid? sourceTicketId,
+        string title,
+        string contentMarkdown,
+        bool aiGenerated,
+        Guid? editedByUserId,
+        DateTime createdUtc)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(title);
         ArgumentException.ThrowIfNullOrWhiteSpace(contentMarkdown);
-        ArgumentException.ThrowIfNullOrWhiteSpace(status);
 
         Id = id == Guid.Empty ? Guid.NewGuid() : id;
         CustomerId = customerId;
+        SourceTicketId = sourceTicketId;
         Title = title.Trim();
         ContentMarkdown = contentMarkdown;
-        Status = status.Trim();
+        Status = KnowledgeArticleStatus.Draft;
+        Version = 1;
+        AiGenerated = aiGenerated;
+        LastEditedByUserId = editedByUserId;
         CreatedUtc = createdUtc;
         UpdatedUtc = createdUtc;
     }
@@ -28,13 +38,84 @@ public sealed class KnowledgeArticle
 
     public Guid? CustomerId { get; private set; }
 
+    public Guid? SourceTicketId { get; private set; }
+
     public string Title { get; private set; }
 
     public string ContentMarkdown { get; private set; }
 
-    public string Status { get; private set; }
+    public KnowledgeArticleStatus Status { get; private set; }
+
+    public int Version { get; private set; }
+
+    public bool AiGenerated { get; private set; }
+
+    public Guid? LastEditedByUserId { get; private set; }
+
+    public Guid? PublishedByUserId { get; private set; }
+
+    public Guid? ArchivedByUserId { get; private set; }
 
     public DateTime CreatedUtc { get; private set; }
 
     public DateTime UpdatedUtc { get; private set; }
+
+    public DateTime? PublishedUtc { get; private set; }
+
+    public DateTime? ArchivedUtc { get; private set; }
+
+    public void UpdateDraft(
+        string title,
+        string contentMarkdown,
+        Guid? editedByUserId,
+        DateTime utcNow)
+    {
+        if (Status != KnowledgeArticleStatus.Draft)
+        {
+            throw new InvalidOperationException("Only draft articles can be edited.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentMarkdown);
+
+        bool hasChanges =
+            !string.Equals(Title, title.Trim(), StringComparison.Ordinal) ||
+            !string.Equals(ContentMarkdown, contentMarkdown, StringComparison.Ordinal);
+
+        Title = title.Trim();
+        ContentMarkdown = contentMarkdown;
+        LastEditedByUserId = editedByUserId;
+        UpdatedUtc = utcNow;
+
+        if (hasChanges)
+        {
+            Version += 1;
+        }
+    }
+
+    public void Publish(Guid? publishedByUserId, DateTime utcNow)
+    {
+        if (Status != KnowledgeArticleStatus.Draft)
+        {
+            throw new InvalidOperationException("Only draft articles can be published.");
+        }
+
+        Status = KnowledgeArticleStatus.Published;
+        PublishedByUserId = publishedByUserId;
+        PublishedUtc = utcNow;
+        UpdatedUtc = utcNow;
+    }
+
+    public void Archive(Guid? archivedByUserId, DateTime utcNow)
+    {
+        if (Status != KnowledgeArticleStatus.Published)
+        {
+            throw new InvalidOperationException("Only published articles can be archived.");
+        }
+
+        Status = KnowledgeArticleStatus.Archived;
+        ArchivedByUserId = archivedByUserId;
+        ArchivedUtc = utcNow;
+        UpdatedUtc = utcNow;
+    }
 }

--- a/src/Helpdesk.Light.Domain/Ai/KnowledgeArticleStatus.cs
+++ b/src/Helpdesk.Light.Domain/Ai/KnowledgeArticleStatus.cs
@@ -1,0 +1,8 @@
+namespace Helpdesk.Light.Domain.Ai;
+
+public enum KnowledgeArticleStatus
+{
+    Draft = 1,
+    Published = 2,
+    Archived = 3
+}

--- a/src/Helpdesk.Light.Domain/Email/OutboundEmailMessage.cs
+++ b/src/Helpdesk.Light.Domain/Email/OutboundEmailMessage.cs
@@ -66,6 +66,8 @@ public sealed class OutboundEmailMessage
 
     public DateTime? SentUtc { get; private set; }
 
+    public DateTime? DeadLetteredUtc { get; private set; }
+
     public void MarkSent(DateTime utcNow)
     {
         Status = OutboundEmailStatus.Sent;
@@ -82,5 +84,25 @@ public sealed class OutboundEmailMessage
     public void MarkAttempt()
     {
         AttemptCount += 1;
+    }
+
+    public void MarkDeadLetter(string reason, DateTime utcNow)
+    {
+        LastError = reason;
+        Status = OutboundEmailStatus.DeadLetter;
+        DeadLetteredUtc = utcNow;
+    }
+
+    public void RetryFromDeadLetter()
+    {
+        if (Status != OutboundEmailStatus.DeadLetter)
+        {
+            throw new InvalidOperationException("Only dead-letter messages can be retried.");
+        }
+
+        Status = OutboundEmailStatus.Pending;
+        LastError = null;
+        DeadLetteredUtc = null;
+        AttemptCount = 0;
     }
 }

--- a/src/Helpdesk.Light.Domain/Email/OutboundEmailStatus.cs
+++ b/src/Helpdesk.Light.Domain/Email/OutboundEmailStatus.cs
@@ -4,5 +4,6 @@ public enum OutboundEmailStatus
 {
     Pending,
     Sent,
-    Failed
+    Failed,
+    DeadLetter
 }

--- a/src/Helpdesk.Light.Infrastructure/Data/SeedData.cs
+++ b/src/Helpdesk.Light.Infrastructure/Data/SeedData.cs
@@ -53,17 +53,26 @@ public static class SeedData
                 new Domain.Ai.KnowledgeArticle(
                     Guid.Parse("01af40de-97f7-44a8-848e-84186f6f2f5d"),
                     null,
+                    null,
                     "Password Reset Basics",
                     "Validate identity before resetting credentials. Enforce MFA reset checks.",
-                    "Published",
+                    aiGenerated: false,
+                    editedByUserId: null,
                     DateTime.UtcNow),
                 new Domain.Ai.KnowledgeArticle(
                     Guid.Parse("3d22ec72-c57e-4fbc-8135-7d8fd6b4be45"),
                     null,
+                    null,
                     "Service Outage Triage",
                     "Confirm scope, impacted services, and rollback path. Provide 30 minute status updates.",
-                    "Published",
+                    aiGenerated: false,
+                    editedByUserId: null,
                     DateTime.UtcNow));
+
+            foreach (Domain.Ai.KnowledgeArticle article in dbContext.KnowledgeArticles.Local.ToList())
+            {
+                article.Publish(null, DateTime.UtcNow);
+            }
 
             await dbContext.SaveChangesAsync(cancellationToken);
         }

--- a/src/Helpdesk.Light.Infrastructure/DependencyInjection.cs
+++ b/src/Helpdesk.Light.Infrastructure/DependencyInjection.cs
@@ -38,8 +38,10 @@ public static class DependencyInjection
             .AddRoles<IdentityRole<Guid>>()
             .AddEntityFrameworkStores<HelpdeskDbContext>();
 
+        services.AddSingleton<IRuntimeMetricsRecorder, RuntimeMetricsRecorder>();
         services.AddScoped<ICustomerAdministrationService, CustomerAdministrationService>();
         services.AddScoped<ITenantResolutionService, TenantResolutionService>();
+        services.AddScoped<IAnalyticsService, AnalyticsService>();
         services.AddScoped<ITicketService, TicketService>();
         services.AddScoped<ITicketAccessGuard, TicketAccessGuard>();
         services.AddScoped<IAttachmentStorage, LocalAttachmentStorage>();
@@ -48,6 +50,7 @@ public static class DependencyInjection
         services.AddScoped<IEmailTransport, ConsoleEmailTransport>();
         services.AddScoped<IAiTicketAgentService, AiTicketAgentService>();
         services.AddScoped<ICustomerAiPolicyService, CustomerAiPolicyService>();
+        services.AddScoped<IKnowledgeBaseService, KnowledgeBaseService>();
 
         return services;
     }

--- a/src/Helpdesk.Light.Infrastructure/Health/AiProviderHealthCheck.cs
+++ b/src/Helpdesk.Light.Infrastructure/Health/AiProviderHealthCheck.cs
@@ -1,0 +1,25 @@
+using Helpdesk.Light.Infrastructure.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Helpdesk.Light.Infrastructure.Health;
+
+public sealed class AiProviderHealthCheck(IOptions<AiOptions> options) : IHealthCheck
+{
+    private readonly AiOptions aiOptions = options.Value;
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (!aiOptions.EnableAi)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy("AI provider is disabled by configuration."));
+        }
+
+        if (string.IsNullOrWhiteSpace(aiOptions.OpenAIApiKey))
+        {
+            return Task.FromResult(HealthCheckResult.Degraded("AI provider key is missing; fallback generation is active."));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy($"AI provider configured with model '{aiOptions.ModelId}'."));
+    }
+}

--- a/src/Helpdesk.Light.Infrastructure/Health/MailAdapterHealthCheck.cs
+++ b/src/Helpdesk.Light.Infrastructure/Health/MailAdapterHealthCheck.cs
@@ -1,0 +1,13 @@
+using Helpdesk.Light.Application.Abstractions.Email;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Helpdesk.Light.Infrastructure.Health;
+
+public sealed class MailAdapterHealthCheck(IEmailTransport emailTransport) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        string adapter = emailTransport.GetType().Name;
+        return Task.FromResult(HealthCheckResult.Healthy($"Mail adapter '{adapter}' is configured."));
+    }
+}

--- a/src/Helpdesk.Light.Infrastructure/Health/SqliteHealthCheck.cs
+++ b/src/Helpdesk.Light.Infrastructure/Health/SqliteHealthCheck.cs
@@ -1,0 +1,15 @@
+using Helpdesk.Light.Infrastructure.Data;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Helpdesk.Light.Infrastructure.Health;
+
+public sealed class SqliteHealthCheck(HelpdeskDbContext dbContext) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        bool canConnect = await dbContext.Database.CanConnectAsync(cancellationToken);
+        return canConnect
+            ? HealthCheckResult.Healthy("SQLite connection is healthy.")
+            : HealthCheckResult.Unhealthy("SQLite connection check failed.");
+    }
+}

--- a/src/Helpdesk.Light.Infrastructure/Helpdesk.Light.Infrastructure.csproj
+++ b/src/Helpdesk.Light.Infrastructure/Helpdesk.Light.Infrastructure.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.70.0" />

--- a/src/Helpdesk.Light.Infrastructure/Services/AnalyticsService.cs
+++ b/src/Helpdesk.Light.Infrastructure/Services/AnalyticsService.cs
@@ -1,0 +1,188 @@
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Application.Errors;
+using Helpdesk.Light.Domain.Ai;
+using Helpdesk.Light.Domain.Tickets;
+using Helpdesk.Light.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Helpdesk.Light.Infrastructure.Services;
+
+public sealed class AnalyticsService(
+    HelpdeskDbContext dbContext,
+    ITenantContextAccessor tenantContextAccessor) : IAnalyticsService
+{
+    public async Task<AnalyticsDashboardDto> GetDashboardAsync(AnalyticsDashboardRequest request, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = tenantContextAccessor.Current;
+        if (!context.IsAuthenticated)
+        {
+            throw new UnauthorizedAccessException("Authentication is required.");
+        }
+
+        DateTime utcNow = DateTime.UtcNow;
+        DateTime rangeEndUtc = request.ToUtc?.ToUniversalTime() ?? utcNow;
+        DateTime rangeStartUtc = request.FromUtc?.ToUniversalTime() ?? rangeEndUtc.AddDays(-30);
+        if (rangeStartUtc > rangeEndUtc)
+        {
+            throw new InvalidOperationException("Range start must be before range end.");
+        }
+
+        Guid? scopedCustomerId = ResolveCustomerScope(context, request.CustomerId);
+
+        IQueryable<Ticket> allTickets = dbContext.Tickets.AsNoTracking();
+        if (scopedCustomerId.HasValue)
+        {
+            allTickets = allTickets.Where(item => item.CustomerId == scopedCustomerId.Value);
+        }
+
+        IQueryable<Ticket> rangedTickets = allTickets
+            .Where(item => item.CreatedUtc >= rangeStartUtc && item.CreatedUtc <= rangeEndUtc);
+
+        int totalTicketVolume = await rangedTickets.CountAsync(cancellationToken);
+        int openTicketCount = await rangedTickets.CountAsync(
+            item => item.Status != TicketStatus.Resolved && item.Status != TicketStatus.Closed,
+            cancellationToken);
+
+        List<Ticket> openTickets = await rangedTickets
+            .Where(item => item.Status != TicketStatus.Resolved && item.Status != TicketStatus.Closed)
+            .ToListAsync(cancellationToken);
+
+        Dictionary<string, int> openByPriority = Enum.GetValues<TicketPriority>()
+            .ToDictionary(value => value.ToString(), value => 0);
+        foreach (Ticket ticket in openTickets)
+        {
+            string key = ticket.Priority.ToString();
+            openByPriority[key] = openByPriority.GetValueOrDefault(key) + 1;
+        }
+
+        Dictionary<string, int> channelSplit = Enum.GetValues<TicketChannel>()
+            .ToDictionary(value => value.ToString(), value => 0);
+        List<Ticket> rangedTicketList = await rangedTickets.ToListAsync(cancellationToken);
+        foreach (Ticket ticket in rangedTicketList)
+        {
+            string key = ticket.Channel.ToString();
+            channelSplit[key] = channelSplit.GetValueOrDefault(key) + 1;
+        }
+
+        List<FirstResponseProjection> firstResponses = await rangedTickets
+            .Select(ticket => new FirstResponseProjection(
+                ticket.CreatedUtc,
+                dbContext.TicketMessages
+                    .Where(message => message.TicketId == ticket.Id &&
+                                      (message.AuthorType == TicketAuthorType.Technician ||
+                                       message.AuthorType == TicketAuthorType.Agent))
+                    .OrderBy(message => message.CreatedUtc)
+                    .Select(message => (DateTime?)message.CreatedUtc)
+                    .FirstOrDefault()))
+            .ToListAsync(cancellationToken);
+
+        List<double> firstResponseMinutes = firstResponses
+            .Where(item => item.FirstResponseUtc.HasValue)
+            .Select(item => (item.FirstResponseUtc!.Value - item.CreatedUtc).TotalMinutes)
+            .Where(item => item >= 0)
+            .ToList();
+
+        double? averageFirstResponse = firstResponseMinutes.Count == 0
+            ? null
+            : firstResponseMinutes.Average();
+
+        List<(DateTime CreatedUtc, DateTime ResolvedUtc)> resolvedTickets = await allTickets
+            .Where(item => item.ResolvedUtc.HasValue &&
+                           item.ResolvedUtc >= rangeStartUtc &&
+                           item.ResolvedUtc <= rangeEndUtc)
+            .Select(item => new ValueTuple<DateTime, DateTime>(item.CreatedUtc, item.ResolvedUtc!.Value))
+            .ToListAsync(cancellationToken);
+
+        List<double> resolutionMinutes = resolvedTickets
+            .Select(item => (item.ResolvedUtc - item.CreatedUtc).TotalMinutes)
+            .Where(item => item >= 0)
+            .ToList();
+
+        double? averageResolution = resolutionMinutes.Count == 0
+            ? null
+            : resolutionMinutes.Average();
+
+        IQueryable<TicketAiSuggestion> aiSuggestions = dbContext.TicketAiSuggestions.AsNoTracking()
+            .Where(item => item.CreatedUtc >= rangeStartUtc && item.CreatedUtc <= rangeEndUtc);
+
+        if (scopedCustomerId.HasValue)
+        {
+            Guid customerId = scopedCustomerId.Value;
+            aiSuggestions = aiSuggestions.Where(item =>
+                dbContext.Tickets.Any(ticket => ticket.Id == item.TicketId && ticket.CustomerId == customerId));
+        }
+
+        int totalAiSuggestions = await aiSuggestions.CountAsync(cancellationToken);
+        int acceptedAiSuggestions = await aiSuggestions.CountAsync(
+            item => item.Status == AiSuggestionStatus.Approved || item.Status == AiSuggestionStatus.AutoSent,
+            cancellationToken);
+        int autoResponseCount = await aiSuggestions.CountAsync(
+            item => item.Status == AiSuggestionStatus.AutoSent,
+            cancellationToken);
+
+        IQueryable<KnowledgeArticle> aiArticles = dbContext.KnowledgeArticles.AsNoTracking()
+            .Where(item => item.AiGenerated && item.CreatedUtc >= rangeStartUtc && item.CreatedUtc <= rangeEndUtc);
+
+        if (scopedCustomerId.HasValue)
+        {
+            Guid customerId = scopedCustomerId.Value;
+            aiArticles = aiArticles.Where(item => item.CustomerId == customerId);
+        }
+
+        int aiGeneratedArticleCount = await aiArticles.CountAsync(cancellationToken);
+        int publishedAiGeneratedArticleCount = await aiArticles.CountAsync(
+            item => item.PublishedUtc.HasValue,
+            cancellationToken);
+
+        return new AnalyticsDashboardDto(
+            rangeStartUtc,
+            rangeEndUtc,
+            totalTicketVolume,
+            openTicketCount,
+            averageFirstResponse,
+            averageResolution,
+            openByPriority,
+            channelSplit,
+            totalAiSuggestions,
+            acceptedAiSuggestions,
+            autoResponseCount,
+            aiGeneratedArticleCount,
+            publishedAiGeneratedArticleCount,
+            RateOrZero(acceptedAiSuggestions, totalAiSuggestions),
+            RateOrZero(autoResponseCount, totalAiSuggestions),
+            RateOrZero(publishedAiGeneratedArticleCount, aiGeneratedArticleCount));
+    }
+
+    private static Guid? ResolveCustomerScope(TenantAccessContext context, Guid? requestedCustomerId)
+    {
+        if (context.IsMspAdmin)
+        {
+            return requestedCustomerId;
+        }
+
+        if (!context.CustomerId.HasValue)
+        {
+            throw new UnauthorizedAccessException("Authenticated user is missing tenant context.");
+        }
+
+        if (requestedCustomerId.HasValue && requestedCustomerId.Value != context.CustomerId.Value)
+        {
+            throw new TenantAccessDeniedException("Cannot access analytics for another tenant.");
+        }
+
+        return context.CustomerId.Value;
+    }
+
+    private static double RateOrZero(int numerator, int denominator)
+    {
+        if (denominator <= 0)
+        {
+            return 0;
+        }
+
+        return (double)numerator / denominator;
+    }
+
+    private sealed record FirstResponseProjection(DateTime CreatedUtc, DateTime? FirstResponseUtc);
+}

--- a/src/Helpdesk.Light.Infrastructure/Services/CustomerAiPolicyService.cs
+++ b/src/Helpdesk.Light.Infrastructure/Services/CustomerAiPolicyService.cs
@@ -1,11 +1,16 @@
+using System.Text.Json;
+using Helpdesk.Light.Application.Abstractions;
 using Helpdesk.Light.Application.Abstractions.Ai;
 using Helpdesk.Light.Application.Contracts.Ai;
+using Helpdesk.Light.Domain.Tickets;
 using Helpdesk.Light.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 
 namespace Helpdesk.Light.Infrastructure.Services;
 
-public sealed class CustomerAiPolicyService(HelpdeskDbContext dbContext) : ICustomerAiPolicyService
+public sealed class CustomerAiPolicyService(
+    HelpdeskDbContext dbContext,
+    ITenantContextAccessor tenantContextAccessor) : ICustomerAiPolicyService
 {
     public async Task UpdatePolicyAsync(Guid customerId, CustomerAiPolicyUpdateRequest request, CancellationToken cancellationToken = default)
     {
@@ -13,6 +18,14 @@ public sealed class CustomerAiPolicyService(HelpdeskDbContext dbContext) : ICust
             ?? throw new KeyNotFoundException($"Customer '{customerId}' was not found.");
 
         customer.SetAiPolicy(request.Mode, request.AutoRespondMinConfidence);
+        dbContext.AuditEvents.Add(new AuditEvent(
+            Guid.NewGuid(),
+            customerId,
+            tenantContextAccessor.Current.UserId,
+            "admin.customer.ai_policy.updated",
+            JsonSerializer.Serialize(new { customerId, request.Mode, request.AutoRespondMinConfidence }),
+            DateTime.UtcNow));
+
         await dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Helpdesk.Light.Infrastructure/Services/KnowledgeBaseService.cs
+++ b/src/Helpdesk.Light.Infrastructure/Services/KnowledgeBaseService.cs
@@ -1,0 +1,477 @@
+using System.Text.Json;
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Abstractions.Ai;
+using Helpdesk.Light.Application.Contracts.Ai;
+using Helpdesk.Light.Application.Errors;
+using Helpdesk.Light.Domain.Ai;
+using Helpdesk.Light.Domain.Security;
+using Helpdesk.Light.Domain.Tickets;
+using Helpdesk.Light.Infrastructure.Data;
+using Helpdesk.Light.Infrastructure.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+
+namespace Helpdesk.Light.Infrastructure.Services;
+
+public sealed class KnowledgeBaseService : IKnowledgeBaseService
+{
+    private readonly HelpdeskDbContext dbContext;
+    private readonly ITenantContextAccessor tenantContextAccessor;
+    private readonly AiOptions aiOptions;
+    private readonly ILogger<KnowledgeBaseService> logger;
+    private readonly Kernel? kernel;
+
+    public KnowledgeBaseService(
+        HelpdeskDbContext dbContext,
+        ITenantContextAccessor tenantContextAccessor,
+        IOptions<AiOptions> options,
+        ILogger<KnowledgeBaseService> logger)
+    {
+        this.dbContext = dbContext;
+        this.tenantContextAccessor = tenantContextAccessor;
+        aiOptions = options.Value;
+        this.logger = logger;
+        kernel = BuildKernel(aiOptions);
+    }
+
+    public async Task<IReadOnlyList<KnowledgeArticleSummaryDto>> ListAsync(KnowledgeArticleListRequest request, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = RequireAuthenticatedContext();
+
+        IQueryable<KnowledgeArticle> query = dbContext.KnowledgeArticles.AsNoTracking();
+        query = ApplyScope(query, context);
+
+        if (request.CustomerId.HasValue)
+        {
+            EnsureCustomerScope(context, request.CustomerId.Value);
+            query = query.Where(item => item.CustomerId == request.CustomerId.Value);
+        }
+
+        if (request.Status.HasValue)
+        {
+            query = query.Where(item => item.Status == request.Status.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            string search = request.Search.Trim();
+            query = query.Where(item =>
+                EF.Functions.Like(item.Title, $"%{search}%") ||
+                EF.Functions.Like(item.ContentMarkdown, $"%{search}%"));
+        }
+
+        int take = Math.Clamp(request.Take, 1, 300);
+        return await query
+            .OrderByDescending(item => item.UpdatedUtc)
+            .Take(take)
+            .Select(item => ToSummary(item))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<KnowledgeArticleDetailDto?> GetAsync(Guid articleId, CancellationToken cancellationToken = default)
+    {
+        KnowledgeArticle? article = await dbContext.KnowledgeArticles
+            .AsNoTracking()
+            .SingleOrDefaultAsync(item => item.Id == articleId, cancellationToken);
+
+        if (article is null)
+        {
+            return null;
+        }
+
+        EnsureArticleScope(RequireAuthenticatedContext(), article);
+        return ToDetail(article);
+    }
+
+    public async Task<KnowledgeArticleDetailDto> CreateDraftAsync(KnowledgeArticleDraftCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = RequireTechnicianOrAdminContext();
+        DateTime utcNow = DateTime.UtcNow;
+        Guid customerId = ResolveCustomerId(request.CustomerId, context);
+
+        Guid? sourceTicketId = request.SourceTicketId;
+        if (sourceTicketId.HasValue)
+        {
+            Ticket? source = await dbContext.Tickets
+                .AsNoTracking()
+                .SingleOrDefaultAsync(item => item.Id == sourceTicketId.Value, cancellationToken);
+
+            if (source is null)
+            {
+                throw new KeyNotFoundException($"Ticket '{sourceTicketId}' was not found.");
+            }
+
+            if (source.CustomerId != customerId)
+            {
+                throw new TenantAccessDeniedException("Cannot link article to a ticket outside tenant boundary.");
+            }
+        }
+
+        KnowledgeArticle article = new(
+            Guid.NewGuid(),
+            customerId,
+            sourceTicketId,
+            request.Title,
+            request.ContentMarkdown,
+            request.AiGenerated,
+            context.UserId,
+            utcNow);
+
+        dbContext.KnowledgeArticles.Add(article);
+        AddAuditEvent(customerId, context.UserId, "knowledge.article.created", new { articleId = article.Id, article.Title, article.Status, article.AiGenerated });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return ToDetail(article);
+    }
+
+    public async Task<KnowledgeArticleDetailDto> UpdateDraftAsync(Guid articleId, KnowledgeArticleDraftUpdateRequest request, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = RequireTechnicianOrAdminContext();
+
+        KnowledgeArticle article = await dbContext.KnowledgeArticles
+            .SingleOrDefaultAsync(item => item.Id == articleId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Knowledge article '{articleId}' was not found.");
+
+        EnsureArticleScope(context, article);
+        article.UpdateDraft(request.Title, request.ContentMarkdown, context.UserId, DateTime.UtcNow);
+
+        AddAuditEvent(article.CustomerId, context.UserId, "knowledge.article.updated", new { articleId = article.Id, article.Version, article.Status });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return ToDetail(article);
+    }
+
+    public async Task<KnowledgeArticleDetailDto> GenerateDraftFromTicketAsync(Guid ticketId, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = RequireTechnicianOrAdminContext();
+
+        Ticket ticket = await dbContext.Tickets
+            .AsNoTracking()
+            .SingleOrDefaultAsync(item => item.Id == ticketId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Ticket '{ticketId}' was not found.");
+
+        EnsureCustomerScope(context, ticket.CustomerId);
+        if (ticket.Status is not (TicketStatus.Resolved or TicketStatus.Closed))
+        {
+            throw new InvalidOperationException("Knowledge article drafts can only be generated from resolved or closed tickets.");
+        }
+
+        List<TicketMessage> messages = await dbContext.TicketMessages
+            .AsNoTracking()
+            .Where(item => item.TicketId == ticketId)
+            .OrderBy(item => item.CreatedUtc)
+            .ToListAsync(cancellationToken);
+
+        GeneratedArticleDraft draft = await GenerateArticleDraftAsync(ticket, messages, cancellationToken);
+
+        KnowledgeArticle article = new(
+            Guid.NewGuid(),
+            ticket.CustomerId,
+            ticket.Id,
+            draft.Title,
+            draft.ContentMarkdown,
+            aiGenerated: true,
+            context.UserId,
+            DateTime.UtcNow);
+
+        dbContext.KnowledgeArticles.Add(article);
+        AddAuditEvent(ticket.CustomerId, context.UserId, "knowledge.article.generated_from_ticket", new
+        {
+            articleId = article.Id,
+            sourceTicketId = ticket.Id,
+            usedAiModel = draft.UsedAiModel
+        });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return ToDetail(article);
+    }
+
+    public async Task<KnowledgeArticleDetailDto> PublishAsync(Guid articleId, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = RequireTechnicianOrAdminContext();
+
+        KnowledgeArticle article = await dbContext.KnowledgeArticles
+            .SingleOrDefaultAsync(item => item.Id == articleId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Knowledge article '{articleId}' was not found.");
+
+        EnsureArticleScope(context, article);
+        article.Publish(context.UserId, DateTime.UtcNow);
+        AddAuditEvent(article.CustomerId, context.UserId, "knowledge.article.published", new { articleId = article.Id, article.Version });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return ToDetail(article);
+    }
+
+    public async Task<KnowledgeArticleDetailDto> ArchiveAsync(Guid articleId, CancellationToken cancellationToken = default)
+    {
+        TenantAccessContext context = RequireTechnicianOrAdminContext();
+
+        KnowledgeArticle article = await dbContext.KnowledgeArticles
+            .SingleOrDefaultAsync(item => item.Id == articleId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Knowledge article '{articleId}' was not found.");
+
+        EnsureArticleScope(context, article);
+        article.Archive(context.UserId, DateTime.UtcNow);
+        AddAuditEvent(article.CustomerId, context.UserId, "knowledge.article.archived", new { articleId = article.Id, article.Version });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return ToDetail(article);
+    }
+
+    private static Kernel? BuildKernel(AiOptions options)
+    {
+        if (!options.EnableAi || string.IsNullOrWhiteSpace(options.OpenAIApiKey))
+        {
+            return null;
+        }
+
+        IKernelBuilder builder = Kernel.CreateBuilder();
+        builder.AddOpenAIChatCompletion(options.ModelId, options.OpenAIApiKey);
+        return builder.Build();
+    }
+
+    private async Task<GeneratedArticleDraft> GenerateArticleDraftAsync(
+        Ticket ticket,
+        IReadOnlyList<TicketMessage> messages,
+        CancellationToken cancellationToken)
+    {
+        string fallbackTitle = $"Runbook: {ticket.Subject}";
+        string fallbackMarkdown = BuildFallbackArticleMarkdown(ticket, messages);
+
+        if (kernel is null)
+        {
+            return new GeneratedArticleDraft(fallbackTitle, fallbackMarkdown, false);
+        }
+
+        string prompt = BuildKnowledgePrompt(ticket, messages);
+        try
+        {
+            FunctionResult result = await kernel.InvokePromptAsync(prompt, cancellationToken: cancellationToken);
+            string? raw = result.GetValue<string>();
+            GeneratedArticlePayload? payload = ParseGeneratedPayload(raw);
+
+            if (payload is null || string.IsNullOrWhiteSpace(payload.Title) || string.IsNullOrWhiteSpace(payload.ContentMarkdown))
+            {
+                return new GeneratedArticleDraft(fallbackTitle, fallbackMarkdown, false);
+            }
+
+            return new GeneratedArticleDraft(payload.Title.Trim(), payload.ContentMarkdown.Trim(), true);
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Failed to generate knowledge article draft using AI; using fallback.");
+            return new GeneratedArticleDraft(fallbackTitle, fallbackMarkdown, false);
+        }
+    }
+
+    private static string BuildKnowledgePrompt(Ticket ticket, IReadOnlyList<TicketMessage> messages)
+    {
+        string timeline = string.Join("\n", messages.Select(item => $"- [{item.CreatedUtc:O}] {item.AuthorType}: {item.Body}"));
+        return $$"""
+                 You are creating an MSP helpdesk knowledge article from a resolved ticket.
+                 Return JSON only with keys: title, contentMarkdown.
+                 Requirements:
+                 - Make title concise and actionable.
+                 - contentMarkdown must include sections: Summary, Symptoms, Cause, Resolution, Validation, Prevention.
+                 - Use operational tone suitable for technicians.
+                 - Do not include personal data.
+
+                 Ticket reference: {{ticket.ReferenceCode}}
+                 Subject: {{ticket.Subject}}
+                 Category: {{ticket.Category}}
+                 Priority: {{ticket.Priority}}
+                 Conversation timeline:
+                 {{timeline}}
+                 """;
+    }
+
+    private static GeneratedArticlePayload? ParseGeneratedPayload(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(raw);
+            JsonElement root = document.RootElement;
+            string? title = root.TryGetProperty("title", out JsonElement titleElement) ? titleElement.GetString() : null;
+            string? content = root.TryGetProperty("contentMarkdown", out JsonElement contentElement) ? contentElement.GetString() : null;
+            if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(content))
+            {
+                return null;
+            }
+
+            return new GeneratedArticlePayload(title, content);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string BuildFallbackArticleMarkdown(Ticket ticket, IReadOnlyList<TicketMessage> messages)
+    {
+        string latestResolution = messages.LastOrDefault()?.Body ?? ticket.Summary;
+        return $"""
+                ## Summary
+                Ticket `{ticket.ReferenceCode}` was resolved for `{ticket.Subject}`.
+
+                ## Symptoms
+                - User reported: {ticket.Summary}
+
+                ## Cause
+                - Root cause investigation completed by support team.
+
+                ## Resolution
+                - {latestResolution}
+
+                ## Validation
+                - Confirmed service behavior returned to normal after remediation.
+
+                ## Prevention
+                - Capture recurring indicators and update monitoring thresholds for early detection.
+                """;
+    }
+
+    private static KnowledgeArticleSummaryDto ToSummary(KnowledgeArticle article)
+    {
+        return new KnowledgeArticleSummaryDto(
+            article.Id,
+            article.CustomerId,
+            article.SourceTicketId,
+            article.Title,
+            article.Status,
+            article.Version,
+            article.AiGenerated,
+            article.UpdatedUtc);
+    }
+
+    private static KnowledgeArticleDetailDto ToDetail(KnowledgeArticle article)
+    {
+        return new KnowledgeArticleDetailDto(
+            article.Id,
+            article.CustomerId,
+            article.SourceTicketId,
+            article.Title,
+            article.ContentMarkdown,
+            article.Status,
+            article.Version,
+            article.AiGenerated,
+            article.LastEditedByUserId,
+            article.PublishedByUserId,
+            article.ArchivedByUserId,
+            article.CreatedUtc,
+            article.UpdatedUtc,
+            article.PublishedUtc,
+            article.ArchivedUtc);
+    }
+
+    private IQueryable<KnowledgeArticle> ApplyScope(IQueryable<KnowledgeArticle> query, TenantAccessContext context)
+    {
+        if (context.IsMspAdmin)
+        {
+            return query;
+        }
+
+        if (!context.CustomerId.HasValue)
+        {
+            return query.Where(_ => false);
+        }
+
+        return query.Where(item => item.CustomerId == context.CustomerId.Value);
+    }
+
+    private static void EnsureCustomerScope(TenantAccessContext context, Guid customerId)
+    {
+        if (context.IsMspAdmin)
+        {
+            return;
+        }
+
+        if (!context.CustomerId.HasValue || context.CustomerId.Value != customerId)
+        {
+            throw new TenantAccessDeniedException("Knowledge article operation crossed tenant boundary.");
+        }
+    }
+
+    private static void EnsureArticleScope(TenantAccessContext context, KnowledgeArticle article)
+    {
+        if (article.CustomerId.HasValue)
+        {
+            EnsureCustomerScope(context, article.CustomerId.Value);
+            return;
+        }
+
+        if (!context.IsMspAdmin)
+        {
+            throw new TenantAccessDeniedException("Global knowledge articles are restricted to MSP admin.");
+        }
+    }
+
+    private static Guid ResolveCustomerId(Guid? requestedCustomerId, TenantAccessContext context)
+    {
+        if (context.IsMspAdmin)
+        {
+            if (!requestedCustomerId.HasValue || requestedCustomerId.Value == Guid.Empty)
+            {
+                throw new InvalidOperationException("Admin draft creation requires customer id.");
+            }
+
+            return requestedCustomerId.Value;
+        }
+
+        if (!context.CustomerId.HasValue)
+        {
+            throw new UnauthorizedAccessException("Authenticated user is missing tenant context.");
+        }
+
+        if (requestedCustomerId.HasValue && requestedCustomerId.Value != context.CustomerId.Value)
+        {
+            throw new TenantAccessDeniedException("Cannot create knowledge article for another tenant.");
+        }
+
+        return context.CustomerId.Value;
+    }
+
+    private TenantAccessContext RequireAuthenticatedContext()
+    {
+        TenantAccessContext context = tenantContextAccessor.Current;
+        if (!context.IsAuthenticated)
+        {
+            throw new UnauthorizedAccessException("Authentication is required.");
+        }
+
+        return context;
+    }
+
+    private TenantAccessContext RequireTechnicianOrAdminContext()
+    {
+        TenantAccessContext context = RequireAuthenticatedContext();
+        if (!context.IsMspAdmin && !string.Equals(context.Role, RoleNames.Technician, StringComparison.Ordinal))
+        {
+            throw new UnauthorizedAccessException("Technician or admin role is required.");
+        }
+
+        return context;
+    }
+
+    private void AddAuditEvent(Guid? customerId, Guid? actorUserId, string eventType, object payload)
+    {
+        dbContext.AuditEvents.Add(new AuditEvent(
+            Guid.NewGuid(),
+            customerId,
+            actorUserId,
+            eventType,
+            JsonSerializer.Serialize(payload),
+            DateTime.UtcNow));
+    }
+
+    private sealed record GeneratedArticleDraft(string Title, string ContentMarkdown, bool UsedAiModel);
+
+    private sealed record GeneratedArticlePayload(string Title, string ContentMarkdown);
+}

--- a/src/Helpdesk.Light.Infrastructure/Services/OutboundEmailService.cs
+++ b/src/Helpdesk.Light.Infrastructure/Services/OutboundEmailService.cs
@@ -1,6 +1,9 @@
+using System.Text.Json;
+using Helpdesk.Light.Application.Abstractions;
 using Helpdesk.Light.Application.Abstractions.Email;
 using Helpdesk.Light.Application.Contracts.Email;
 using Helpdesk.Light.Domain.Email;
+using Helpdesk.Light.Domain.Tickets;
 using Helpdesk.Light.Infrastructure.Data;
 using Helpdesk.Light.Infrastructure.Options;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +14,8 @@ namespace Helpdesk.Light.Infrastructure.Services;
 public sealed class OutboundEmailService(
     HelpdeskDbContext dbContext,
     IEmailTransport emailTransport,
+    ITenantContextAccessor tenantContextAccessor,
+    IRuntimeMetricsRecorder runtimeMetrics,
     IOptions<EmailOptions> options) : IOutboundEmailService
 {
     private readonly EmailOptions emailOptions = options.Value;
@@ -27,6 +32,12 @@ public sealed class OutboundEmailService(
 
         OutboundEmailMessage message = new(Guid.NewGuid(), ticketId, customerId, toAddress, subject, body, correlationKey, DateTime.UtcNow);
         dbContext.OutboundEmailMessages.Add(message);
+        AddAuditEvent(
+            customerId,
+            tenantContextAccessor.Current.UserId,
+            "email.queued",
+            new { messageId = message.Id, message.TicketId, message.CorrelationKey, message.ToAddress, message.Subject });
+
         await dbContext.SaveChangesAsync(cancellationToken);
 
         await DispatchPendingAsync(cancellationToken);
@@ -35,13 +46,27 @@ public sealed class OutboundEmailService(
     public async Task DispatchPendingAsync(CancellationToken cancellationToken = default)
     {
         List<OutboundEmailMessage> pending = await dbContext.OutboundEmailMessages
-            .Where(item => item.Status != OutboundEmailStatus.Sent && item.AttemptCount < emailOptions.MaxRetryCount)
+            .Where(item => item.Status == OutboundEmailStatus.Pending || item.Status == OutboundEmailStatus.Failed)
             .OrderBy(item => item.CreatedUtc)
             .ToListAsync(cancellationToken);
+
+        runtimeMetrics.SetWorkerQueueDepth(pending.Count);
 
         foreach (OutboundEmailMessage message in pending)
         {
             int remainingAttempts = emailOptions.MaxRetryCount - message.AttemptCount;
+            if (remainingAttempts <= 0)
+            {
+                message.MarkDeadLetter($"Exceeded retry limit ({emailOptions.MaxRetryCount}).", DateTime.UtcNow);
+                runtimeMetrics.RecordEmailDeadLetter();
+                AddAuditEvent(
+                    message.CustomerId,
+                    tenantContextAccessor.Current.UserId,
+                    "email.dead_lettered",
+                    new { messageId = message.Id, message.TicketId, message.AttemptCount, reason = message.LastError });
+                continue;
+            }
+
             for (int index = 0; index < remainingAttempts; index++)
             {
                 message.MarkAttempt();
@@ -50,16 +75,73 @@ public sealed class OutboundEmailService(
                 {
                     await emailTransport.SendAsync(message.ToAddress, message.Subject, message.Body, cancellationToken);
                     message.MarkSent(DateTime.UtcNow);
+                    runtimeMetrics.RecordEmailSent();
+                    AddAuditEvent(
+                        message.CustomerId,
+                        tenantContextAccessor.Current.UserId,
+                        "email.sent",
+                        new { messageId = message.Id, message.TicketId, message.AttemptCount });
                     break;
                 }
                 catch (Exception exception)
                 {
                     message.MarkFailure(exception.Message);
+                    runtimeMetrics.RecordEmailFailed();
+                    AddAuditEvent(
+                        message.CustomerId,
+                        tenantContextAccessor.Current.UserId,
+                        "email.send.failed",
+                        new { messageId = message.Id, message.TicketId, message.AttemptCount, error = exception.Message });
                 }
+            }
+
+            if (message.Status != OutboundEmailStatus.Sent && message.AttemptCount >= emailOptions.MaxRetryCount)
+            {
+                message.MarkDeadLetter($"Exceeded retry limit ({emailOptions.MaxRetryCount}). Last error: {message.LastError}", DateTime.UtcNow);
+                runtimeMetrics.RecordEmailDeadLetter();
+                AddAuditEvent(
+                    message.CustomerId,
+                    tenantContextAccessor.Current.UserId,
+                    "email.dead_lettered",
+                    new { messageId = message.Id, message.TicketId, message.AttemptCount, reason = message.LastError });
             }
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
+
+        int remaining = await dbContext.OutboundEmailMessages
+            .CountAsync(item => item.Status == OutboundEmailStatus.Pending || item.Status == OutboundEmailStatus.Failed, cancellationToken);
+
+        runtimeMetrics.SetWorkerQueueDepth(remaining);
+    }
+
+    public async Task<int> RetryDeadLettersAsync(int take = 50, CancellationToken cancellationToken = default)
+    {
+        int boundedTake = Math.Clamp(take, 1, 500);
+        List<OutboundEmailMessage> deadLetters = await dbContext.OutboundEmailMessages
+            .Where(item => item.Status == OutboundEmailStatus.DeadLetter)
+            .OrderBy(item => item.CreatedUtc)
+            .Take(boundedTake)
+            .ToListAsync(cancellationToken);
+
+        if (deadLetters.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (OutboundEmailMessage message in deadLetters)
+        {
+            message.RetryFromDeadLetter();
+            AddAuditEvent(
+                message.CustomerId,
+                tenantContextAccessor.Current.UserId,
+                "email.dead_letter.retry_requested",
+                new { messageId = message.Id, message.TicketId, message.AttemptCount });
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await DispatchPendingAsync(cancellationToken);
+        return deadLetters.Count;
     }
 
     public async Task<IReadOnlyList<OutboundEmailDto>> ListAsync(Guid? customerId, CancellationToken cancellationToken = default)
@@ -84,7 +166,19 @@ public sealed class OutboundEmailService(
                 item.AttemptCount,
                 item.LastError,
                 item.CreatedUtc,
-                item.SentUtc))
+                item.SentUtc,
+                item.DeadLetteredUtc))
             .ToListAsync(cancellationToken);
+    }
+
+    private void AddAuditEvent(Guid customerId, Guid? actorUserId, string eventType, object payload)
+    {
+        dbContext.AuditEvents.Add(new AuditEvent(
+            Guid.NewGuid(),
+            customerId,
+            actorUserId,
+            eventType,
+            JsonSerializer.Serialize(payload),
+            DateTime.UtcNow));
     }
 }

--- a/src/Helpdesk.Light.Infrastructure/Services/RuntimeMetricsRecorder.cs
+++ b/src/Helpdesk.Light.Infrastructure/Services/RuntimeMetricsRecorder.cs
@@ -1,0 +1,137 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Contracts;
+
+namespace Helpdesk.Light.Infrastructure.Services;
+
+public sealed class RuntimeMetricsRecorder : IRuntimeMetricsRecorder
+{
+    private const int MaxFailureEntries = 50;
+
+    private static readonly Meter Meter = new("Helpdesk.Light.Observability", "1.0.0");
+    private static readonly Counter<long> ApiRequestCounter = Meter.CreateCounter<long>("helpdesk.api.requests.total");
+    private static readonly Counter<long> ApiErrorCounter = Meter.CreateCounter<long>("helpdesk.api.errors.total");
+    private static readonly Histogram<double> ApiLatencyHistogram = Meter.CreateHistogram<double>("helpdesk.api.latency.ms", "ms");
+    private static readonly Counter<long> EmailOutcomeCounter = Meter.CreateCounter<long>("helpdesk.email.outcomes.total");
+    private static readonly Counter<long> AiRunCounter = Meter.CreateCounter<long>("helpdesk.ai.runs.total");
+    private static readonly Histogram<double> AiDurationHistogram = Meter.CreateHistogram<double>("helpdesk.ai.duration.ms", "ms");
+
+    private readonly ConcurrentQueue<WorkerFailureDto> recentFailures = new();
+
+    private long apiRequestCount;
+    private long apiErrorCount;
+    private long apiLatencySampleCount;
+    private long apiLatencyMicrosecondsTotal;
+
+    private int workerQueueDepth;
+
+    private long emailSentCount;
+    private long emailFailedCount;
+    private long emailDeadLetterCount;
+
+    private long aiRunCount;
+    private long aiRunFailureCount;
+    private long aiDurationSampleCount;
+    private long aiDurationMicrosecondsTotal;
+
+    public RuntimeMetricsRecorder()
+    {
+        Meter.CreateObservableGauge("helpdesk.worker.queue.depth", () => Volatile.Read(ref workerQueueDepth));
+    }
+
+    public void RecordApiRequest(int statusCode, double latencyMs)
+    {
+        Interlocked.Increment(ref apiRequestCount);
+        ApiRequestCounter.Add(1);
+
+        if (statusCode >= 400)
+        {
+            Interlocked.Increment(ref apiErrorCount);
+            ApiErrorCounter.Add(1);
+        }
+
+        long microseconds = Math.Max(0, (long)(latencyMs * 1000));
+        Interlocked.Increment(ref apiLatencySampleCount);
+        Interlocked.Add(ref apiLatencyMicrosecondsTotal, microseconds);
+        ApiLatencyHistogram.Record(latencyMs);
+    }
+
+    public void SetWorkerQueueDepth(int depth)
+    {
+        Interlocked.Exchange(ref workerQueueDepth, Math.Max(0, depth));
+    }
+
+    public void RecordEmailSent()
+    {
+        Interlocked.Increment(ref emailSentCount);
+        EmailOutcomeCounter.Add(1, new KeyValuePair<string, object?>("outcome", "sent"));
+    }
+
+    public void RecordEmailFailed()
+    {
+        Interlocked.Increment(ref emailFailedCount);
+        EmailOutcomeCounter.Add(1, new KeyValuePair<string, object?>("outcome", "failed"));
+    }
+
+    public void RecordEmailDeadLetter()
+    {
+        Interlocked.Increment(ref emailDeadLetterCount);
+        EmailOutcomeCounter.Add(1, new KeyValuePair<string, object?>("outcome", "dead_letter"));
+    }
+
+    public void RecordAiRun(double durationMs, bool success)
+    {
+        Interlocked.Increment(ref aiRunCount);
+        AiRunCounter.Add(1, new KeyValuePair<string, object?>("outcome", success ? "success" : "failed"));
+
+        if (!success)
+        {
+            Interlocked.Increment(ref aiRunFailureCount);
+        }
+
+        long microseconds = Math.Max(0, (long)(durationMs * 1000));
+        Interlocked.Increment(ref aiDurationSampleCount);
+        Interlocked.Add(ref aiDurationMicrosecondsTotal, microseconds);
+        AiDurationHistogram.Record(durationMs, new KeyValuePair<string, object?>("success", success));
+    }
+
+    public void RecordWorkerFailure(string worker, string error)
+    {
+        WorkerFailureDto failure = new(DateTime.UtcNow, worker, error);
+        recentFailures.Enqueue(failure);
+
+        while (recentFailures.Count > MaxFailureEntries)
+        {
+            _ = recentFailures.TryDequeue(out _);
+        }
+    }
+
+    public OperationsMetricsDto GetSnapshot()
+    {
+        long apiSamples = Interlocked.Read(ref apiLatencySampleCount);
+        long aiSamples = Interlocked.Read(ref aiDurationSampleCount);
+
+        double averageApiLatencyMs = apiSamples == 0
+            ? 0
+            : Interlocked.Read(ref apiLatencyMicrosecondsTotal) / 1000d / apiSamples;
+
+        double averageAiDurationMs = aiSamples == 0
+            ? 0
+            : Interlocked.Read(ref aiDurationMicrosecondsTotal) / 1000d / aiSamples;
+
+        return new OperationsMetricsDto(
+            DateTime.UtcNow,
+            Interlocked.Read(ref apiRequestCount),
+            Interlocked.Read(ref apiErrorCount),
+            averageApiLatencyMs,
+            Volatile.Read(ref workerQueueDepth),
+            Interlocked.Read(ref emailSentCount),
+            Interlocked.Read(ref emailFailedCount),
+            Interlocked.Read(ref emailDeadLetterCount),
+            Interlocked.Read(ref aiRunCount),
+            Interlocked.Read(ref aiRunFailureCount),
+            averageAiDurationMs,
+            recentFailures.ToArray());
+    }
+}

--- a/src/Helpdesk.Light.Web/Layout/NavMenu.razor
+++ b/src/Helpdesk.Light.Web/Layout/NavMenu.razor
@@ -48,6 +48,15 @@
             <span class="nav-arrow" aria-hidden="true">></span>
         </NavLink>
 
+        <NavLink href="/knowledge" class="nav-item" @onclick="HandleNavigate">
+            <span class="nav-icon">KB</span>
+            <span class="nav-copy">
+                <span class="nav-label">Knowledge</span>
+                <small>Drafts, publish, and archive lifecycle</small>
+            </span>
+            <span class="nav-arrow" aria-hidden="true">></span>
+        </NavLink>
+
         <NavLink href="/login" class="nav-item" @onclick="HandleNavigate">
             <span class="nav-icon">AU</span>
             <span class="nav-copy">

--- a/src/Helpdesk.Light.Web/Pages/Home.razor
+++ b/src/Helpdesk.Light.Web/Pages/Home.razor
@@ -1,26 +1,308 @@
 @page "/"
+@inject HelpdeskApiClient Api
+@inject ClientSession Session
+@implements IDisposable
 
 <PageTitle>Helpdesk-Light Dashboard</PageTitle>
 
-<section class="hero">
-    <h1>AI-enabled Helpdesk Operations</h1>
-    <p>Multi-customer MSP support with tenant boundaries, secure authentication, and Semantic Kernel-ready workflows.</p>
-</section>
+<h1>Operations Dashboard</h1>
+<p>Live KPIs for ticket operations, AI outcomes, and channel mix.</p>
 
-<section class="kpi-grid">
-    <article class="kpi-card">
-        <h2>Ticket Intake</h2>
-        <strong>Web + Email</strong>
-        <p>Dual-channel lodgement supports direct portal submissions and domain-mapped inbound email.</p>
-    </article>
-    <article class="kpi-card">
-        <h2>Tenant Safety</h2>
-        <strong>Strict isolation</strong>
-        <p>Role-aware access ensures technicians only access their assigned customer tenant.</p>
-    </article>
-    <article class="kpi-card">
-        <h2>Admin Control</h2>
-        <strong>Customer domains</strong>
-        <p>MSP admins create customers and configure domain mappings for automatic routing.</p>
-    </article>
-</section>
+@if (!Session.IsAuthenticated)
+{
+    <section class="panel">
+        <h2>Authentication Required</h2>
+        <p>Sign in to view tenant-scoped dashboard analytics.</p>
+        <a href="/login" class="button-link">Go to Login</a>
+    </section>
+}
+else
+{
+    <section class="panel-grid">
+        <section class="panel">
+            <h2>Filters</h2>
+            @if (IsAdmin)
+            {
+                <label>
+                    <span>Customer</span>
+                    <InputSelect @bind-Value="selectedCustomerIdText">
+                        <option value="">All customers</option>
+                        @foreach (CustomerSummaryDto customer in customers)
+                        {
+                            <option value="@customer.Id.ToString()">@customer.Name</option>
+                        }
+                    </InputSelect>
+                </label>
+            }
+
+            <label>
+                <span>From (UTC date)</span>
+                <InputDate @bind-Value="fromDate" />
+            </label>
+            <label>
+                <span>To (UTC date)</span>
+                <InputDate @bind-Value="toDate" />
+            </label>
+
+            <button type="button" @onclick="LoadDashboardAsync" disabled="@isBusy">Refresh Dashboard</button>
+            <p class="hint">KPI definitions: <code>Helpdesk-Light/03-KPI-Definitions.md</code></p>
+        </section>
+
+        <section class="panel">
+            <h2>Date Window</h2>
+            @if (dashboard is null)
+            {
+                <p>No data loaded yet.</p>
+            }
+            else
+            {
+                <p><strong>From:</strong> @dashboard.RangeStartUtc.ToString("u")</p>
+                <p><strong>To:</strong> @dashboard.RangeEndUtc.ToString("u")</p>
+                <p><strong>Tenant Scope:</strong> @(selectedCustomerId.HasValue ? selectedCustomerId.Value.ToString() : "Current access scope")</p>
+            }
+        </section>
+    </section>
+
+    @if (dashboard is not null)
+    {
+        <section class="kpi-grid">
+            <article class="kpi-card">
+                <h2>Ticket Volume</h2>
+                <strong>@dashboard.TotalTicketVolume</strong>
+                <p>Tickets created in range</p>
+            </article>
+            <article class="kpi-card">
+                <h2>Open Tickets</h2>
+                <strong>@dashboard.OpenTicketCount</strong>
+                <p>Current open queue in range</p>
+            </article>
+            <article class="kpi-card">
+                <h2>First Response</h2>
+                <strong>@FormatMinutes(dashboard.AverageFirstResponseMinutes)</strong>
+                <p>Average time to first technician/agent response</p>
+            </article>
+            <article class="kpi-card">
+                <h2>Resolution Time</h2>
+                <strong>@FormatMinutes(dashboard.AverageResolutionMinutes)</strong>
+                <p>Average time from creation to resolution</p>
+            </article>
+            <article class="kpi-card">
+                <h2>AI Acceptance</h2>
+                <strong>@FormatRate(dashboard.SuggestionAcceptanceRate)</strong>
+                <p>@dashboard.AcceptedAiSuggestions of @dashboard.TotalAiSuggestions suggestions accepted</p>
+            </article>
+            <article class="kpi-card">
+                <h2>Auto Response</h2>
+                <strong>@FormatRate(dashboard.AutoResponseRate)</strong>
+                <p>@dashboard.AutoResponseCount automated responses sent</p>
+            </article>
+        </section>
+
+        <section class="panel-grid">
+            <section class="panel">
+                <h2>Open Tickets By Priority</h2>
+                <ul>
+                    @foreach (KeyValuePair<string, int> pair in dashboard.OpenTicketsByPriority.OrderBy(item => item.Key))
+                    {
+                        <li><strong>@pair.Key:</strong> @pair.Value</li>
+                    }
+                </ul>
+            </section>
+
+            <section class="panel">
+                <h2>Channel Split</h2>
+                <ul>
+                    @foreach (KeyValuePair<string, int> pair in dashboard.ChannelSplit.OrderBy(item => item.Key))
+                    {
+                        <li><strong>@pair.Key:</strong> @pair.Value</li>
+                    }
+                </ul>
+            </section>
+
+            <section class="panel">
+                <h2>AI Article Draft Acceptance</h2>
+                <p><strong>@FormatRate(dashboard.ArticleDraftAcceptanceRate)</strong></p>
+                <p>@dashboard.PublishedAiGeneratedArticleCount of @dashboard.AiGeneratedArticleCount AI-generated drafts were published.</p>
+            </section>
+        </section>
+
+        @if (IsAdmin && operationsMetrics is not null)
+        {
+            <section class="panel-grid">
+                <section class="panel">
+                    <h2>Runtime Metrics</h2>
+                    <p><strong>API Requests:</strong> @operationsMetrics.ApiRequestCount (errors: @operationsMetrics.ApiErrorCount)</p>
+                    <p><strong>Average API Latency:</strong> @operationsMetrics.AverageApiLatencyMs.ToString("N1") ms</p>
+                    <p><strong>Worker Queue Depth:</strong> @operationsMetrics.WorkerQueueDepth</p>
+                    <p><strong>Email Outcomes:</strong> Sent @operationsMetrics.EmailSentCount, Failed @operationsMetrics.EmailFailedCount, Dead-letter @operationsMetrics.EmailDeadLetterCount</p>
+                    <p><strong>AI Runtime:</strong> @operationsMetrics.AiRunCount runs, @operationsMetrics.AiRunFailureCount failures, avg @operationsMetrics.AverageAiDurationMs.ToString("N1") ms</p>
+                </section>
+
+                <section class="panel">
+                    <h2>Recent Worker Failures</h2>
+                    @if (operationsMetrics.RecentWorkerFailures.Count == 0)
+                    {
+                        <p>No worker failures recorded in current runtime.</p>
+                    }
+                    else
+                    {
+                        <ul>
+                            @foreach (WorkerFailureDto failure in operationsMetrics.RecentWorkerFailures.OrderByDescending(item => item.CreatedUtc).Take(10))
+                            {
+                                <li><strong>@failure.CreatedUtc.ToLocalTime()</strong> @failure.Worker: @failure.Error</li>
+                            }
+                        </ul>
+                    }
+                </section>
+            </section>
+        }
+    }
+
+    @if (!string.IsNullOrWhiteSpace(statusMessage))
+    {
+        <section class="panel">
+            <p class="status">@statusMessage</p>
+        </section>
+    }
+}
+
+@code {
+    private readonly List<CustomerSummaryDto> customers = [];
+
+    private AnalyticsDashboardDto? dashboard;
+    private OperationsMetricsDto? operationsMetrics;
+    private bool isBusy;
+    private string statusMessage = string.Empty;
+
+    private string selectedCustomerIdText = string.Empty;
+    private Guid? selectedCustomerId;
+
+    private DateTime? fromDate = DateTime.UtcNow.Date.AddDays(-30);
+    private DateTime? toDate = DateTime.UtcNow.Date;
+
+    private bool IsAdmin => Session.Role == "MspAdmin";
+
+    protected override async Task OnInitializedAsync()
+    {
+        Session.Changed += OnSessionChanged;
+
+        if (!Session.IsAuthenticated)
+        {
+            return;
+        }
+
+        await LoadCustomersIfNeededAsync();
+        await LoadDashboardAsync();
+    }
+
+    private void OnSessionChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            if (!Session.IsAuthenticated)
+            {
+                customers.Clear();
+                dashboard = null;
+                operationsMetrics = null;
+                statusMessage = string.Empty;
+                selectedCustomerIdText = string.Empty;
+                selectedCustomerId = null;
+                StateHasChanged();
+                return;
+            }
+
+            await LoadCustomersIfNeededAsync();
+            await LoadDashboardAsync();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadCustomersIfNeededAsync()
+    {
+        if (!IsAdmin)
+        {
+            customers.Clear();
+            selectedCustomerIdText = string.Empty;
+            selectedCustomerId = null;
+            return;
+        }
+
+        if (customers.Count > 0)
+        {
+            return;
+        }
+
+        try
+        {
+            IReadOnlyList<CustomerSummaryDto> loaded = await Api.ListCustomersAsync();
+            customers.Clear();
+            customers.AddRange(loaded.OrderBy(item => item.Name));
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to load customer filter list: {exception.Message}";
+        }
+    }
+
+    private async Task LoadDashboardAsync()
+    {
+        if (!Session.IsAuthenticated)
+        {
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            selectedCustomerId = ParseGuidNullable(selectedCustomerIdText);
+            DateTime? fromUtc = fromDate.HasValue
+                ? DateTime.SpecifyKind(fromDate.Value.Date, DateTimeKind.Utc)
+                : null;
+
+            DateTime? toUtc = toDate.HasValue
+                ? DateTime.SpecifyKind(toDate.Value.Date, DateTimeKind.Utc).AddDays(1).AddTicks(-1)
+                : null;
+
+            if (fromUtc.HasValue && toUtc.HasValue && fromUtc > toUtc)
+            {
+                statusMessage = "From date must be on or before To date.";
+                return;
+            }
+
+            dashboard = await Api.GetDashboardAsync(new AnalyticsDashboardRequest(selectedCustomerId, fromUtc, toUtc));
+            operationsMetrics = IsAdmin
+                ? await Api.GetOperationsMetricsAsync()
+                : null;
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to load dashboard: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private static Guid? ParseGuidNullable(string? raw)
+    {
+        return Guid.TryParse(raw, out Guid value) ? value : null;
+    }
+
+    private static string FormatMinutes(double? value)
+    {
+        return value.HasValue ? $"{value.Value:N1} min" : "N/A";
+    }
+
+    private static string FormatRate(double value)
+    {
+        return $"{value * 100:N1}%";
+    }
+
+    public void Dispose()
+    {
+        Session.Changed -= OnSessionChanged;
+    }
+}

--- a/src/Helpdesk.Light.Web/Pages/Knowledge.razor
+++ b/src/Helpdesk.Light.Web/Pages/Knowledge.razor
@@ -1,0 +1,425 @@
+@page "/knowledge"
+@inject HelpdeskApiClient Api
+@inject ClientSession Session
+@implements IDisposable
+
+<PageTitle>Knowledge Base</PageTitle>
+
+<h1>Knowledge Base</h1>
+<p>Review, edit, and publish tenant-scoped support articles generated from resolved tickets.</p>
+
+@if (!Session.IsAuthenticated)
+{
+    <section class="panel">
+        <h2>Authentication Required</h2>
+        <p>Sign in to access knowledge workflows.</p>
+        <a href="/login" class="button-link">Go to Login</a>
+    </section>
+}
+else if (!CanManageKnowledge)
+{
+    <section class="panel">
+        <h2>Access Restricted</h2>
+        <p>Knowledge authoring is limited to technician and admin roles.</p>
+    </section>
+}
+else
+{
+    <section class="panel-grid">
+        <section class="panel">
+            <h2>Generate Draft</h2>
+            <label>
+                <span>Resolved Ticket Id</span>
+                <input @bind="generateTicketIdText" placeholder="Guid" />
+            </label>
+            <button type="button" @onclick="GenerateFromTicketAsync" disabled="@isBusy">Generate from Ticket</button>
+        </section>
+
+        <section class="panel">
+            <h2>Filter Articles</h2>
+            <label>
+                <span>Status</span>
+                <select @bind="filterStatusText">
+                    <option value="">Any</option>
+                    @foreach (KnowledgeArticleStatus status in Enum.GetValues<KnowledgeArticleStatus>())
+                    {
+                        <option value="@status">@status</option>
+                    }
+                </select>
+            </label>
+            <label>
+                <span>Search</span>
+                <input @bind="searchText" placeholder="Title or content" />
+            </label>
+            @if (IsAdmin)
+            {
+                <label>
+                    <span>Customer</span>
+                    <InputSelect @bind-Value="filterCustomerId">
+                        <option value="">All customers</option>
+                        @foreach (AdminCustomerOption customer in adminCustomers)
+                        {
+                            <option value="@customer.Id">@customer.Name (@customer.Id)</option>
+                        }
+                    </InputSelect>
+                </label>
+            }
+            <button type="button" @onclick="LoadArticlesAsync" disabled="@isBusy">Refresh</button>
+        </section>
+    </section>
+
+    <section class="panel-grid">
+        <section class="panel">
+            <h2>Article List (@articles.Count)</h2>
+            @if (articles.Count == 0)
+            {
+                <p>No articles matched the filter.</p>
+            }
+            else
+            {
+                <div class="ticket-list">
+                    @foreach (KnowledgeArticleSummaryDto article in articles)
+                    {
+                        <button type="button" class="ticket-row @(selectedArticle?.Id == article.Id ? "selected" : string.Empty)" @onclick="() => SelectArticleAsync(article.Id)">
+                            <span>@article.Status</span>
+                            <span>@article.Title</span>
+                            <span>v@article.Version</span>
+                            <span>@(article.AiGenerated ? "AI Draft" : "Manual")</span>
+                            <span>@article.UpdatedUtc.ToLocalTime()</span>
+                        </button>
+                    }
+                </div>
+            }
+        </section>
+
+        <section class="panel">
+            <h2>@(selectedArticle is null ? "Create Draft" : "Edit Draft")</h2>
+            <label>
+                <span>Title</span>
+                <input @bind="editTitle" />
+            </label>
+            <label>
+                <span>Content (Markdown)</span>
+                <textarea rows="12" @bind="editContent"></textarea>
+            </label>
+            @if (IsAdmin && selectedArticle is null)
+            {
+                <label>
+                    <span>Customer</span>
+                    <InputSelect @bind-Value="newArticleCustomerId">
+                        @if (adminCustomers.Count == 0)
+                        {
+                            <option value="">No customers</option>
+                        }
+                        else
+                        {
+                            @foreach (AdminCustomerOption customer in adminCustomers)
+                            {
+                                <option value="@customer.Id">@customer.Name (@customer.Id)</option>
+                            }
+                        }
+                    </InputSelect>
+                </label>
+            }
+
+            @if (selectedArticle is null)
+            {
+                <button type="button" @onclick="CreateDraftAsync" disabled="@isBusy">Create Draft</button>
+            }
+            else
+            {
+                <p>Status: <strong>@selectedArticle.Status</strong> | Version: <strong>@selectedArticle.Version</strong></p>
+                <button type="button" @onclick="SaveDraftAsync" disabled="@isBusy || selectedArticle.Status != KnowledgeArticleStatus.Draft">Save Draft</button>
+                <button type="button" @onclick="PublishAsync" disabled="@isBusy || selectedArticle.Status != KnowledgeArticleStatus.Draft">Publish</button>
+                <button type="button" @onclick="ArchiveAsync" disabled="@isBusy || selectedArticle.Status != KnowledgeArticleStatus.Published">Archive</button>
+            }
+        </section>
+    </section>
+
+    @if (!string.IsNullOrWhiteSpace(statusMessage))
+    {
+        <section class="panel"><p class="status">@statusMessage</p></section>
+    }
+}
+
+@code {
+    private sealed record AdminCustomerOption(Guid Id, string Name, bool IsActive, int DomainCount);
+
+    private readonly List<AdminCustomerOption> adminCustomers = [];
+    private readonly List<KnowledgeArticleSummaryDto> articles = [];
+
+    private KnowledgeArticleDetailDto? selectedArticle;
+    private bool isBusy;
+    private string statusMessage = string.Empty;
+    private string filterStatusText = string.Empty;
+    private string searchText = string.Empty;
+    private Guid? filterCustomerId;
+    private Guid? newArticleCustomerId;
+    private string generateTicketIdText = string.Empty;
+    private string editTitle = string.Empty;
+    private string editContent = string.Empty;
+
+    private bool IsAdmin => Session.Role == "MspAdmin";
+    private bool CanManageKnowledge => Session.Role is "Technician" or "MspAdmin";
+
+    protected override async Task OnInitializedAsync()
+    {
+        Session.Changed += OnSessionChanged;
+        if (Session.IsAuthenticated && CanManageKnowledge)
+        {
+            await EnsureAdminCustomersLoadedAsync();
+            await LoadArticlesAsync();
+        }
+    }
+
+    private void OnSessionChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            selectedArticle = null;
+            statusMessage = string.Empty;
+            articles.Clear();
+            adminCustomers.Clear();
+
+            if (Session.IsAuthenticated && CanManageKnowledge)
+            {
+                await EnsureAdminCustomersLoadedAsync();
+                await LoadArticlesAsync();
+            }
+
+            StateHasChanged();
+        });
+    }
+
+    private async Task EnsureAdminCustomersLoadedAsync()
+    {
+        if (!IsAdmin)
+        {
+            return;
+        }
+
+        IReadOnlyList<Helpdesk.Light.Application.Contracts.CustomerSummaryDto> customers = await Api.ListCustomersAsync();
+
+        adminCustomers.Clear();
+        adminCustomers.AddRange(customers.Select(item => new AdminCustomerOption(item.Id, item.Name, item.IsActive, item.DomainCount)));
+
+        if (!newArticleCustomerId.HasValue && adminCustomers.Count > 0)
+        {
+            newArticleCustomerId = adminCustomers[0].Id;
+        }
+    }
+
+    private async Task LoadArticlesAsync()
+    {
+        if (!CanManageKnowledge)
+        {
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            KnowledgeArticleStatus? status = Enum.TryParse<KnowledgeArticleStatus>(filterStatusText, out KnowledgeArticleStatus parsed)
+                ? parsed
+                : null;
+
+            Guid? customerId = IsAdmin ? filterCustomerId : null;
+            IReadOnlyList<KnowledgeArticleSummaryDto> loaded = await Api.ListKnowledgeArticlesAsync(
+                new KnowledgeArticleListRequest(searchText, status, customerId, 200));
+
+            articles.Clear();
+            articles.AddRange(loaded);
+            if (selectedArticle is not null && articles.All(item => item.Id != selectedArticle.Id))
+            {
+                selectedArticle = null;
+            }
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to load knowledge articles: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task SelectArticleAsync(Guid articleId)
+    {
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            selectedArticle = await Api.GetKnowledgeArticleAsync(articleId);
+            if (selectedArticle is not null)
+            {
+                editTitle = selectedArticle.Title;
+                editContent = selectedArticle.ContentMarkdown;
+            }
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to load article: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task CreateDraftAsync()
+    {
+        if (string.IsNullOrWhiteSpace(editTitle) || string.IsNullOrWhiteSpace(editContent))
+        {
+            statusMessage = "Title and content are required.";
+            return;
+        }
+
+        if (IsAdmin && !newArticleCustomerId.HasValue)
+        {
+            statusMessage = "Select a customer before creating an admin article.";
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            KnowledgeArticleDetailDto created = await Api.CreateKnowledgeDraftAsync(
+                new KnowledgeArticleDraftCreateRequest(
+                    IsAdmin ? newArticleCustomerId : null,
+                    null,
+                    editTitle,
+                    editContent,
+                    AiGenerated: false));
+
+            selectedArticle = created;
+            await LoadArticlesAsync();
+            statusMessage = $"Draft article created: {created.Title}.";
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to create draft: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task SaveDraftAsync()
+    {
+        if (selectedArticle is null)
+        {
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            selectedArticle = await Api.UpdateKnowledgeDraftAsync(selectedArticle.Id, new KnowledgeArticleDraftUpdateRequest(editTitle, editContent));
+            await LoadArticlesAsync();
+            statusMessage = "Draft saved.";
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to save draft: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task PublishAsync()
+    {
+        if (selectedArticle is null)
+        {
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            selectedArticle = await Api.PublishKnowledgeArticleAsync(selectedArticle.Id);
+            await LoadArticlesAsync();
+            statusMessage = "Article published.";
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to publish article: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task ArchiveAsync()
+    {
+        if (selectedArticle is null)
+        {
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            selectedArticle = await Api.ArchiveKnowledgeArticleAsync(selectedArticle.Id);
+            await LoadArticlesAsync();
+            statusMessage = "Article archived.";
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to archive article: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task GenerateFromTicketAsync()
+    {
+        if (!Guid.TryParse(generateTicketIdText, out Guid ticketId))
+        {
+            statusMessage = "Provide a valid resolved ticket id.";
+            return;
+        }
+
+        isBusy = true;
+        statusMessage = string.Empty;
+
+        try
+        {
+            selectedArticle = await Api.GenerateKnowledgeDraftFromTicketAsync(ticketId);
+            editTitle = selectedArticle.Title;
+            editContent = selectedArticle.ContentMarkdown;
+            await LoadArticlesAsync();
+            statusMessage = $"AI draft generated from ticket {ticketId}.";
+        }
+        catch (Exception exception)
+        {
+            statusMessage = $"Failed to generate draft: {exception.Message}";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        Session.Changed -= OnSessionChanged;
+    }
+}

--- a/src/Helpdesk.Light.Worker/Worker.cs
+++ b/src/Helpdesk.Light.Worker/Worker.cs
@@ -1,3 +1,4 @@
+using Helpdesk.Light.Application.Abstractions;
 using Helpdesk.Light.Application.Abstractions.Email;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -5,6 +6,7 @@ namespace Helpdesk.Light.Worker;
 
 public sealed class Worker(
     ILogger<Worker> logger,
+    IRuntimeMetricsRecorder runtimeMetrics,
     IServiceScopeFactory scopeFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -20,6 +22,7 @@ public sealed class Worker(
             catch (Exception exception)
             {
                 logger.LogError(exception, "Outbound dispatch cycle failed.");
+                runtimeMetrics.RecordWorkerFailure(nameof(Worker), exception.Message);
             }
 
             try

--- a/tests/Helpdesk.Light.IntegrationTests/AnalyticsAndOperationsIntegrationTests.cs
+++ b/tests/Helpdesk.Light.IntegrationTests/AnalyticsAndOperationsIntegrationTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Net.Http.Json;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Application.Contracts.Tickets;
+using Helpdesk.Light.Domain.Email;
+using Helpdesk.Light.Domain.Tickets;
+using Helpdesk.Light.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Helpdesk.Light.IntegrationTests;
+
+public sealed class AnalyticsAndOperationsIntegrationTests(HelpdeskApiFactory factory) : IClassFixture<HelpdeskApiFactory>
+{
+    [Fact]
+    public async Task Dashboard_IsFilterableAndTenantScoped()
+    {
+        using HttpClient contosoUserClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(contosoUserClient, SeedDataConstants.ContosoEndUserEmail);
+
+        await contosoUserClient.PostAsJsonAsync("/api/v1/tickets", new CreateTicketRequest(
+            null,
+            "Contoso dashboard validation",
+            "Create analytics event in contoso tenant.",
+            TicketPriority.Medium));
+
+        using HttpClient fabrikamUserClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(fabrikamUserClient, SeedDataConstants.FabrikamEndUserEmail);
+
+        await fabrikamUserClient.PostAsJsonAsync("/api/v1/tickets", new CreateTicketRequest(
+            null,
+            "Fabrikam dashboard validation",
+            "Create analytics event in fabrikam tenant.",
+            TicketPriority.High));
+
+        string fromUtc = Uri.EscapeDataString(DateTime.UtcNow.AddHours(-2).ToString("O"));
+        string toUtc = Uri.EscapeDataString(DateTime.UtcNow.AddHours(1).ToString("O"));
+
+        using HttpClient contosoTechClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(contosoTechClient, SeedDataConstants.ContosoTechEmail);
+
+        HttpResponseMessage forbidden = await contosoTechClient.GetAsync(
+            $"/api/v1/analytics/dashboard?customerId={SeedDataConstants.FabrikamCustomerId}&fromUtc={fromUtc}&toUtc={toUtc}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, forbidden.StatusCode);
+
+        using HttpClient adminClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(adminClient, SeedDataConstants.AdminEmail);
+
+        HttpResponseMessage contosoDashboardResponse = await adminClient.GetAsync(
+            $"/api/v1/analytics/dashboard?customerId={SeedDataConstants.ContosoCustomerId}&fromUtc={fromUtc}&toUtc={toUtc}");
+
+        contosoDashboardResponse.EnsureSuccessStatusCode();
+        Assert.True(contosoDashboardResponse.Headers.Contains("X-Correlation-ID"));
+
+        AnalyticsDashboardDto contosoDashboard = (await contosoDashboardResponse.Content.ReadFromJsonAsync<AnalyticsDashboardDto>(TestAuth.JsonOptions))!;
+        Assert.True(contosoDashboard.TotalTicketVolume >= 1);
+        Assert.True(contosoDashboard.ChannelSplit.GetValueOrDefault("Web") >= 1);
+    }
+
+    [Fact]
+    public async Task HealthEndpoints_AreAnonymous()
+    {
+        using HttpClient client = factory.CreateClient();
+
+        HttpResponseMessage live = await client.GetAsync("/health/live");
+        HttpResponseMessage ready = await client.GetAsync("/health/ready");
+
+        Assert.Equal(HttpStatusCode.OK, live.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, ready.StatusCode);
+
+        string liveBody = await live.Content.ReadAsStringAsync();
+        string readyBody = await ready.Content.ReadAsStringAsync();
+
+        Assert.Contains("status", liveBody, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("status", readyBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Admin_CanQueryAndRetryDeadLetterMessages()
+    {
+        Guid deadLetterId;
+
+        using (IServiceScope scope = factory.Services.CreateScope())
+        {
+            HelpdeskDbContext dbContext = scope.ServiceProvider.GetRequiredService<HelpdeskDbContext>();
+            OutboundEmailMessage message = new(
+                Guid.NewGuid(),
+                null,
+                SeedDataConstants.ContosoCustomerId,
+                SeedDataConstants.ContosoEndUserEmail,
+                "Dead letter test",
+                "This should be retried",
+                $"dead-letter-test:{Guid.NewGuid():N}",
+                DateTime.UtcNow);
+
+            message.MarkAttempt();
+            message.MarkAttempt();
+            message.MarkAttempt();
+            message.MarkDeadLetter("Forced dead letter for integration test", DateTime.UtcNow);
+            dbContext.OutboundEmailMessages.Add(message);
+            await dbContext.SaveChangesAsync();
+            deadLetterId = message.Id;
+        }
+
+        using HttpClient adminClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(adminClient, SeedDataConstants.AdminEmail);
+
+        HttpResponseMessage deadLetterListResponse = await adminClient.GetAsync("/api/v1/ops/dead-letters?take=100");
+        deadLetterListResponse.EnsureSuccessStatusCode();
+
+        List<DeadLetterMessageDto> deadLetters = (await deadLetterListResponse.Content.ReadFromJsonAsync<List<DeadLetterMessageDto>>(TestAuth.JsonOptions))!;
+        Assert.Contains(deadLetters, item => item.Id == deadLetterId);
+
+        HttpResponseMessage retryResponse = await adminClient.PostAsync("/api/v1/email/outbound/retry-dead-letter?take=100", null);
+        retryResponse.EnsureSuccessStatusCode();
+
+        using IServiceScope verifyScope = factory.Services.CreateScope();
+        HelpdeskDbContext verifyDbContext = verifyScope.ServiceProvider.GetRequiredService<HelpdeskDbContext>();
+        OutboundEmailMessage? retried = await verifyDbContext.OutboundEmailMessages.SingleOrDefaultAsync(item => item.Id == deadLetterId);
+
+        Assert.NotNull(retried);
+        Assert.Equal(OutboundEmailStatus.Sent, retried!.Status);
+    }
+
+    [Fact]
+    public async Task AdminActions_WriteAuditTrailEvents()
+    {
+        using HttpClient adminClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(adminClient, SeedDataConstants.AdminEmail);
+
+        string suffix = Guid.NewGuid().ToString("N")[..8];
+        HttpResponseMessage createResponse = await adminClient.PostAsJsonAsync("/api/v1/admin/customers", new
+        {
+            name = $"Audit-Customer-{suffix}",
+            isActive = true
+        });
+
+        createResponse.EnsureSuccessStatusCode();
+        var created = await createResponse.Content.ReadFromJsonAsync<CustomerPayload>(TestAuth.JsonOptions);
+        Assert.NotNull(created);
+
+        using IServiceScope scope = factory.Services.CreateScope();
+        HelpdeskDbContext dbContext = scope.ServiceProvider.GetRequiredService<HelpdeskDbContext>();
+
+        bool hasAuditEvent = await dbContext.AuditEvents.AnyAsync(item =>
+            item.EventType == "admin.customer.created" && item.CustomerId == created!.Id);
+
+        Assert.True(hasAuditEvent);
+    }
+
+    private sealed record CustomerPayload(Guid Id, string Name, bool IsActive, int DomainCount);
+}

--- a/tests/Helpdesk.Light.IntegrationTests/EndToEndWorkflowIntegrationTests.cs
+++ b/tests/Helpdesk.Light.IntegrationTests/EndToEndWorkflowIntegrationTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Http.Json;
+using Helpdesk.Light.Application.Contracts.Ai;
+using Helpdesk.Light.Application.Contracts.Tickets;
+using Helpdesk.Light.Domain.Ai;
+using Helpdesk.Light.Domain.Tickets;
+using Helpdesk.Light.Infrastructure.Data;
+
+namespace Helpdesk.Light.IntegrationTests;
+
+public sealed class EndToEndWorkflowIntegrationTests(HelpdeskApiFactory factory) : IClassFixture<HelpdeskApiFactory>
+{
+    [Fact]
+    public async Task LoginToResolutionAndKnowledgePublish_Workflow_Completes()
+    {
+        using HttpClient endUserClient = factory.CreateClient();
+        TestAuth.LoginResponse endUser = await TestAuth.LoginAndSetAuthHeaderAsync(endUserClient, SeedDataConstants.ContosoEndUserEmail);
+
+        HttpResponseMessage createResponse = await endUserClient.PostAsJsonAsync("/api/v1/tickets", new CreateTicketRequest(
+            null,
+            "End-to-end workflow validation",
+            "Need a full support lifecycle validation.",
+            TicketPriority.Medium));
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        TicketSummaryDto createdTicket = (await createResponse.Content.ReadFromJsonAsync<TicketSummaryDto>(TestAuth.JsonOptions))!;
+        Assert.Equal(TicketStatus.New, createdTicket.Status);
+
+        using HttpClient techClient = factory.CreateClient();
+        TestAuth.LoginResponse technician = await TestAuth.LoginAndSetAuthHeaderAsync(techClient, SeedDataConstants.ContosoTechEmail);
+
+        HttpResponseMessage assignResponse = await techClient.PostAsJsonAsync($"/api/v1/tickets/{createdTicket.Id}/assign", new TicketAssignRequest(technician.UserId));
+        assignResponse.EnsureSuccessStatusCode();
+
+        HttpResponseMessage inProgressResponse = await techClient.PostAsJsonAsync(
+            $"/api/v1/tickets/{createdTicket.Id}/status",
+            new TicketStatusUpdateRequest(TicketStatus.InProgress));
+        inProgressResponse.EnsureSuccessStatusCode();
+
+        HttpResponseMessage replyResponse = await techClient.PostAsJsonAsync(
+            $"/api/v1/tickets/{createdTicket.Id}/messages",
+            new TicketMessageCreateRequest("Technician investigating and applying fix."));
+        replyResponse.EnsureSuccessStatusCode();
+
+        HttpResponseMessage resolveResponse = await techClient.PostAsJsonAsync(
+            $"/api/v1/tickets/{createdTicket.Id}/status",
+            new TicketStatusUpdateRequest(TicketStatus.Resolved));
+        resolveResponse.EnsureSuccessStatusCode();
+
+        TicketSummaryDto resolved = (await resolveResponse.Content.ReadFromJsonAsync<TicketSummaryDto>(TestAuth.JsonOptions))!;
+        Assert.Equal(TicketStatus.Resolved, resolved.Status);
+
+        HttpResponseMessage draftResponse = await techClient.PostAsync($"/api/v1/knowledge/articles/from-ticket/{createdTicket.Id}", null);
+        Assert.Equal(HttpStatusCode.Created, draftResponse.StatusCode);
+
+        KnowledgeArticleDetailDto draft = (await draftResponse.Content.ReadFromJsonAsync<KnowledgeArticleDetailDto>(TestAuth.JsonOptions))!;
+        Assert.Equal(KnowledgeArticleStatus.Draft, draft.Status);
+
+        HttpResponseMessage publishResponse = await techClient.PostAsync($"/api/v1/knowledge/articles/{draft.Id}/publish", null);
+        publishResponse.EnsureSuccessStatusCode();
+
+        KnowledgeArticleDetailDto published = (await publishResponse.Content.ReadFromJsonAsync<KnowledgeArticleDetailDto>(TestAuth.JsonOptions))!;
+        Assert.Equal(KnowledgeArticleStatus.Published, published.Status);
+
+        HttpResponseMessage detailResponse = await endUserClient.GetAsync($"/api/v1/tickets/{createdTicket.Id}");
+        detailResponse.EnsureSuccessStatusCode();
+
+        TicketDetailDto detail = (await detailResponse.Content.ReadFromJsonAsync<TicketDetailDto>(TestAuth.JsonOptions))!;
+        Assert.Contains(detail.Messages, item => item.AuthorType == TicketAuthorType.Technician);
+        Assert.Equal(TicketStatus.Resolved, detail.Ticket.Status);
+        Assert.Equal(endUser.UserId, detail.Ticket.CreatedByUserId);
+    }
+}

--- a/tests/Helpdesk.Light.IntegrationTests/KnowledgeBaseIntegrationTests.cs
+++ b/tests/Helpdesk.Light.IntegrationTests/KnowledgeBaseIntegrationTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Json;
+using Helpdesk.Light.Application.Contracts.Ai;
+using Helpdesk.Light.Application.Contracts.Tickets;
+using Helpdesk.Light.Domain.Ai;
+using Helpdesk.Light.Domain.Tickets;
+using Helpdesk.Light.Infrastructure.Data;
+
+namespace Helpdesk.Light.IntegrationTests;
+
+public sealed class KnowledgeBaseIntegrationTests(HelpdeskApiFactory factory) : IClassFixture<HelpdeskApiFactory>
+{
+    [Fact]
+    public async Task ResolvedTicket_CanGeneratePublishAndListKnowledgeArticle()
+    {
+        using HttpClient userClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(userClient, SeedDataConstants.ContosoEndUserEmail);
+
+        TicketSummaryDto createdTicket = (await (await userClient.PostAsJsonAsync("/api/v1/tickets", new CreateTicketRequest(
+            null,
+            "VPN reconnect guide needed",
+            "Users need a repeatable reconnect process.",
+            TicketPriority.Medium))).Content.ReadFromJsonAsync<TicketSummaryDto>(TestAuth.JsonOptions))!;
+
+        using HttpClient techClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(techClient, SeedDataConstants.ContosoTechEmail);
+
+        HttpResponseMessage resolveResponse = await techClient.PostAsJsonAsync(
+            $"/api/v1/tickets/{createdTicket.Id}/status",
+            new TicketStatusUpdateRequest(TicketStatus.Resolved));
+
+        resolveResponse.EnsureSuccessStatusCode();
+
+        HttpResponseMessage generateResponse = await techClient.PostAsync($"/api/v1/knowledge/articles/from-ticket/{createdTicket.Id}", null);
+        Assert.Equal(HttpStatusCode.Created, generateResponse.StatusCode);
+
+        KnowledgeArticleDetailDto draft = (await generateResponse.Content.ReadFromJsonAsync<KnowledgeArticleDetailDto>(TestAuth.JsonOptions))!;
+        Assert.Equal(KnowledgeArticleStatus.Draft, draft.Status);
+        Assert.Equal(createdTicket.Id, draft.SourceTicketId);
+        Assert.True(draft.AiGenerated);
+
+        HttpResponseMessage publishResponse = await techClient.PostAsync($"/api/v1/knowledge/articles/{draft.Id}/publish", null);
+        publishResponse.EnsureSuccessStatusCode();
+
+        KnowledgeArticleDetailDto published = (await publishResponse.Content.ReadFromJsonAsync<KnowledgeArticleDetailDto>(TestAuth.JsonOptions))!;
+        Assert.Equal(KnowledgeArticleStatus.Published, published.Status);
+
+        HttpResponseMessage listResponse = await techClient.GetAsync("/api/v1/knowledge/articles?status=Published&take=50");
+        listResponse.EnsureSuccessStatusCode();
+
+        List<KnowledgeArticleSummaryDto> list = (await listResponse.Content.ReadFromJsonAsync<List<KnowledgeArticleSummaryDto>>(TestAuth.JsonOptions))!;
+        Assert.Contains(list, item => item.Id == draft.Id);
+    }
+
+    [Fact]
+    public async Task Technician_CannotReadKnowledgeArticleOutsideTenant()
+    {
+        using HttpClient adminClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(adminClient, SeedDataConstants.AdminEmail);
+
+        HttpResponseMessage createResponse = await adminClient.PostAsJsonAsync(
+            "/api/v1/knowledge/articles",
+            new KnowledgeArticleDraftCreateRequest(
+                SeedDataConstants.ContosoCustomerId,
+                null,
+                "Contoso-only Article",
+                "Tenant-bound content",
+                false));
+
+        createResponse.EnsureSuccessStatusCode();
+        KnowledgeArticleDetailDto created = (await createResponse.Content.ReadFromJsonAsync<KnowledgeArticleDetailDto>(TestAuth.JsonOptions))!;
+
+        using HttpClient fabrikamTechClient = factory.CreateClient();
+        await TestAuth.LoginAndSetAuthHeaderAsync(fabrikamTechClient, SeedDataConstants.FabrikamTechEmail);
+
+        HttpResponseMessage forbidden = await fabrikamTechClient.GetAsync($"/api/v1/knowledge/articles/{created.Id}");
+        Assert.Equal(HttpStatusCode.Forbidden, forbidden.StatusCode);
+    }
+}

--- a/tests/Helpdesk.Light.UnitTests/KnowledgeArticleLifecycleTests.cs
+++ b/tests/Helpdesk.Light.UnitTests/KnowledgeArticleLifecycleTests.cs
@@ -1,0 +1,55 @@
+using Helpdesk.Light.Domain.Ai;
+
+namespace Helpdesk.Light.UnitTests;
+
+public sealed class KnowledgeArticleLifecycleTests
+{
+    [Fact]
+    public void Draft_UpdateAndPublishArchiveFlow_Succeeds()
+    {
+        DateTime createdUtc = DateTime.UtcNow;
+
+        KnowledgeArticle article = new(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Original title",
+            "Original content",
+            aiGenerated: true,
+            editedByUserId: Guid.NewGuid(),
+            createdUtc);
+
+        article.UpdateDraft("Updated title", "Updated content", Guid.NewGuid(), createdUtc.AddMinutes(5));
+
+        Assert.Equal(KnowledgeArticleStatus.Draft, article.Status);
+        Assert.Equal(2, article.Version);
+
+        article.Publish(Guid.NewGuid(), createdUtc.AddMinutes(10));
+
+        Assert.Equal(KnowledgeArticleStatus.Published, article.Status);
+        Assert.NotNull(article.PublishedUtc);
+
+        article.Archive(Guid.NewGuid(), createdUtc.AddMinutes(20));
+
+        Assert.Equal(KnowledgeArticleStatus.Archived, article.Status);
+        Assert.NotNull(article.ArchivedUtc);
+    }
+
+    [Fact]
+    public void Publish_NonDraft_Throws()
+    {
+        KnowledgeArticle article = new(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            null,
+            "Title",
+            "Content",
+            aiGenerated: false,
+            editedByUserId: null,
+            DateTime.UtcNow);
+
+        article.Publish(Guid.NewGuid(), DateTime.UtcNow);
+
+        Assert.Throws<InvalidOperationException>(() => article.Publish(Guid.NewGuid(), DateTime.UtcNow));
+    }
+}

--- a/tests/Helpdesk.Light.UnitTests/OutboundEmailMessageReliabilityTests.cs
+++ b/tests/Helpdesk.Light.UnitTests/OutboundEmailMessageReliabilityTests.cs
@@ -1,0 +1,50 @@
+using Helpdesk.Light.Domain.Email;
+
+namespace Helpdesk.Light.UnitTests;
+
+public sealed class OutboundEmailMessageReliabilityTests
+{
+    [Fact]
+    public void MarkDeadLetter_ThenRetry_ResetsStateToPending()
+    {
+        OutboundEmailMessage message = new(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "user@contoso.com",
+            "Subject",
+            "Body",
+            "correlation-key",
+            DateTime.UtcNow);
+
+        message.MarkAttempt();
+        message.MarkFailure("smtp failure");
+        message.MarkDeadLetter("Exceeded retries", DateTime.UtcNow);
+
+        Assert.Equal(OutboundEmailStatus.DeadLetter, message.Status);
+        Assert.NotNull(message.DeadLetteredUtc);
+
+        message.RetryFromDeadLetter();
+
+        Assert.Equal(OutboundEmailStatus.Pending, message.Status);
+        Assert.Null(message.DeadLetteredUtc);
+        Assert.Null(message.LastError);
+        Assert.Equal(0, message.AttemptCount);
+    }
+
+    [Fact]
+    public void RetryFromDeadLetter_NonDeadLetter_Throws()
+    {
+        OutboundEmailMessage message = new(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "user@contoso.com",
+            "Subject",
+            "Body",
+            "correlation-key",
+            DateTime.UtcNow);
+
+        Assert.Throws<InvalidOperationException>(() => message.RetryFromDeadLetter());
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves Helpdesk-Light issues **#15 through #20** on branch `codex/helpdesk-light-issues-15-20`.

The implementation moves the project from a baseline ticketing app to a production-shaped MSP helpdesk platform with:

- full knowledge-base lifecycle management
- operational + AI analytics dashboarding
- observability (correlation IDs, health checks, runtime metrics)
- background reliability improvements (retry + dead-letter)
- backup/restore tooling and runbooks
- expanded automated tests across unit, integration, and end-to-end workflow paths
- deployment packaging and environment templates for API/Worker/Web

## User Impact / Problem Statement

Before this change:

- KB workflows were not fully lifecycle-driven (draft/publish/archive + ticket-derived article workflows were incomplete).
- There was no comprehensive analytics API/UI for MSP operational and AI KPIs.
- Observability for real troubleshooting was limited (no correlation IDs, no health/readiness checks, no runtime metrics endpoint).
- Outbound background reliability had retries but no dead-letter lifecycle and no admin retry path.
- Backup/restore and deployment guidance/artifacts were incomplete for repeatable environments.
- Coverage for KB and end-to-end support flow requirements was incomplete.

After this change:

- MSP admins and technicians can generate, edit, publish, and archive KB articles including AI-generated drafts from resolved tickets.
- Dashboard KPIs are filterable by date and customer scope and include operational + AI metrics with documented KPI definitions.
- API requests carry correlation IDs, health endpoints report dependency status, and runtime metrics expose API/worker/email/AI behavior.
- Failed outbound emails are dead-lettered after threshold and can be retried by admins.
- Backup and restore are scripted with integrity checks and documented procedures.
- Repo includes reproducible deployment templates, Docker packaging, and expanded test coverage.

## Root Cause and Technical Approach

The core gap was that domain/service boundaries existed but lacked full implementation for late-stage operational requirements (analytics, observability, reliability, and deployment readiness). This PR addresses that by extending contracts and services at each layer and validating behavior with automated tests.

## Changes by Issue

### #15 Knowledge base lifecycle and workflows

- Added `KnowledgeArticleStatus` enum and lifecycle behavior in `KnowledgeArticle` (draft updates, publish, archive, versioning, actor tracking, source ticket linkage).
- Added KB contracts and abstraction (`IKnowledgeBaseService`) and implemented `KnowledgeBaseService`.
- Added KB API controller with list/get/create/update/generate-from-ticket/publish/archive endpoints.
- Added tenant-scope and role checks for technician/admin workflows.
- Added UI page (`/knowledge`) and navigation integration.
- Updated EF Core mappings and seed data for KB lifecycle model.

### #16 Operational and AI analytics dashboard

- Added analytics contracts (`AnalyticsDashboardRequest/Dto`) and `IAnalyticsService`.
- Implemented `AnalyticsService` with:
  - ticket volume, open queue, first response time, resolution time
  - open by priority, channel split
  - AI suggestion acceptance, auto-response rate, AI article draft acceptance
  - tenant/customer/date filtering with enforced tenant boundaries
- Added API endpoint: `GET /api/v1/analytics/dashboard`.
- Reworked home dashboard UI to display live analytics with admin customer filtering.
- Added KPI definitions doc: `Helpdesk-Light/03-KPI-Definitions.md`.

### #17 Observability, auditing, and health diagnostics

- Added JSON structured logging with scope-enabled correlation IDs.
- Added `CorrelationIdMiddleware` (`X-Correlation-ID` request/response propagation).
- Added readiness/liveness endpoints:
  - `GET /health/live`
  - `GET /health/ready`
- Added custom health checks:
  - SQLite connectivity
  - mail adapter presence
  - AI provider configuration status
- Added runtime metrics recorder (`IRuntimeMetricsRecorder` + `RuntimeMetricsRecorder`) tracking:
  - API request/error counts and latency
  - worker queue depth
  - email outcomes (sent/failed/dead-letter)
  - AI run count/failure/duration
  - recent worker failures
- Added operations diagnostics endpoints:
  - `GET /api/v1/ops/metrics`
  - `GET /api/v1/ops/dead-letters`
- Expanded auditing for admin operations and inbound email ticket actions.

### #18 Backup/restore and background reliability

- Extended outbound email reliability with explicit `DeadLetter` state and dead-letter timestamp.
- Added retry endpoint and service method:
  - `POST /api/v1/email/outbound/retry-dead-letter`
- Added retry-from-dead-letter lifecycle behavior in domain model.
- Added operational scripts:
  - `scripts/backup-helpdesk.sh`
  - `scripts/restore-helpdesk.sh`
- Added runbook: `docs/operations-runbook.md`.

### #19 Comprehensive automated test suite

Added/expanded tests to cover domain, integration, and workflow paths:

- Unit tests:
  - `KnowledgeArticleLifecycleTests`
  - `OutboundEmailMessageReliabilityTests`
- Integration tests:
  - `KnowledgeBaseIntegrationTests`
  - `AnalyticsAndOperationsIntegrationTests`
  - `EndToEndWorkflowIntegrationTests`

Coverage includes:

- tenant boundary checks
- analytics filtering and authorization
- health endpoint behavior
- dead-letter retry behavior
- full login -> ticket -> technician -> resolution -> KB publish workflow

### #20 Deployment packaging and environment configuration

- Added Docker packaging:
  - `docker/Dockerfile.api`
  - `docker/Dockerfile.worker`
  - `docker/Dockerfile.web`
  - `docker-compose.yml`
  - `.dockerignore`
- Added deployment templates:
  - `deploy/appsettings.Api.Production.template.json`
  - `deploy/appsettings.Worker.Production.template.json`
  - `deploy/appsettings.Web.Production.template.json`
  - `deploy/nginx/helpdesk-web.conf`
- Added environment example: `.env.example`
- Added image build script: `scripts/build-images.sh`
- Added deployment guide: `docs/deployment.md`
- Updated `README.md` with build/test/health/ops/backup/deployment commands.

## Validation

Commands executed successfully:

```bash
dotnet build Helpdesk.Light.slnx --nologo -warnaserror
dotnet test Helpdesk.Light.slnx --nologo
```

Results:

- Build: **0 errors, 0 warnings**
- Tests: **41 passed, 0 failed**

## Risks / Notes

- AI readiness is reported as degraded (not unhealthy) when AI is enabled without API key; fallback generation remains available.
- Runtime metrics are in-memory and reset on process restart.
- Dead-letter retry resets attempt count to allow a fresh retry cycle.

## Linked Issues

- Closes #15
- Closes #16
- Closes #17
- Closes #18
- Closes #19
- Closes #20
