### PR TITLE
[codex] Resolve open issues with reliability, analytics, and test hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    tags-ignore:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build-test:
+    name: Build and Test (.NET 10)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.103
+
+      - name: Restore
+        run: dotnet restore Helpdesk.Light.slnx
+
+      - name: Build
+        run: dotnet build Helpdesk.Light.slnx --configuration Release --no-restore -warnaserror
+
+      - name: Test
+        run: >
+          dotnet test Helpdesk.Light.slnx
+          --configuration Release
+          --no-build
+          --collect:"XPlat Code Coverage"
+          --logger "trx;LogFileName=test-results.trx"
+          --results-directory artifacts/test-results
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: artifacts/test-results
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: CD Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag to publish (example: v1.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cd-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  package-runtime:
+    name: Package ${{ matrix.component }} (${{ matrix.rid }})
+    if: ${{ github.event_name != 'release' || github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - api
+          - worker
+        rid:
+          - linux-x64
+          - linux-arm64
+          - win-x64
+          - osx-x64
+          - osx-arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.103
+
+      - name: Restore
+        run: dotnet restore Helpdesk.Light.slnx
+
+      - name: Publish package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ matrix.component }}" in
+            api)
+              CSPROJ="src/Helpdesk.Light.Api/Helpdesk.Light.Api.csproj"
+              ;;
+            worker)
+              CSPROJ="src/Helpdesk.Light.Worker/Helpdesk.Light.Worker.csproj"
+              ;;
+            *)
+              echo "Unknown component: ${{ matrix.component }}"
+              exit 1
+              ;;
+          esac
+
+          OUT_DIR="artifacts/publish/${{ matrix.component }}-${{ matrix.rid }}"
+          ASSET_PATH="artifacts/release/helpdesk-light-${{ matrix.component }}-${{ matrix.rid }}.tar.gz"
+          mkdir -p artifacts/release
+
+          dotnet publish "$CSPROJ" \
+            --configuration Release \
+            --runtime "${{ matrix.rid }}" \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:EnableCompressionInSingleFile=true \
+            -p:PublishTrimmed=false \
+            -p:DebugType=None \
+            -p:DebugSymbols=false \
+            --output "$OUT_DIR"
+
+          tar -C "$OUT_DIR" -czf "$ASSET_PATH" .
+
+      - name: Upload packaged runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.component }}-${{ matrix.rid }}
+          path: artifacts/release/*.tar.gz
+          if-no-files-found: error
+
+  package-web:
+    name: Package web (static)
+    if: ${{ github.event_name != 'release' || github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.103
+
+      - name: Restore
+        run: dotnet restore src/Helpdesk.Light.Web/Helpdesk.Light.Web.csproj
+
+      - name: Publish web app
+        run: dotnet publish src/Helpdesk.Light.Web/Helpdesk.Light.Web.csproj --configuration Release --no-restore --output artifacts/publish/web
+
+      - name: Create web static package
+        run: |
+          mkdir -p artifacts/release
+          tar -C artifacts/publish/web/wwwroot -czf artifacts/release/helpdesk-light-web-static.tar.gz .
+
+      - name: Upload packaged web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-web-static
+          path: artifacts/release/helpdesk-light-web-static.tar.gz
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish release assets
+    if: ${{ github.event_name != 'release' || github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - package-runtime
+      - package-web
+
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum *.tar.gz > SHA256SUMS.txt
+
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.release_tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+
+          echo "value=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create/update release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.value }}
+          generate_release_notes: true
+          overwrite_files: true
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -108,5 +108,6 @@ KPI definitions are documented in `Helpdesk-Light/03-KPI-Definitions.md`.
 ## Deployment
 
 - Deployment docs: `docs/deployment.md`
+- Release readiness and hardening checklist: `docs/release-readiness-security.md`
 - Config templates: `deploy/`
 - Container assets: `docker/` + `docker-compose.yml`

--- a/docs/release-readiness-security.md
+++ b/docs/release-readiness-security.md
@@ -1,0 +1,51 @@
+# Release Readiness and Security Hardening
+
+## Objective
+
+This document tracks MVP hardening status for security, privacy, and release readiness.
+
+## Authorization and Tenant Isolation Coverage
+
+Coverage is enforced in service/controller authorization checks and validated by integration tests, including:
+
+- `AuthAndTenancyIntegrationTests.Technician_CannotAccessAnotherTenantCustomerData`
+- `AuthAndTenancyIntegrationTests.Technician_CannotCallAdminCustomersEndpoint`
+- `TicketLifecycleIntegrationTests.EndUser_CannotReadOtherTenantTicket`
+- `KnowledgeBaseIntegrationTests.Technician_CannotReadKnowledgeArticleOutsideTenant`
+- `ResolverGroupIntegrationTests.Assignment_ToOtherCustomerResolverGroup_IsRejected`
+- `TicketCategoryIntegrationTests.CategoryMapping_ToDifferentCustomerResolverGroup_IsRejected`
+
+## Input Sanitization and Attachment Safeguards
+
+Current safeguards include:
+
+- Attachment uploads enforce max-size and content-type allowlists (`LocalAttachmentStorage`).
+- Attachment file names are normalized with invalid characters replaced (`LocalAttachmentStorage`).
+- Knowledge article search now escapes SQL LIKE wildcard characters before query execution (`KnowledgeBaseService`).
+
+## AI Guardrails and Restricted Categories
+
+Current safeguards include:
+
+- Customer-level AI policy modes with confidence threshold checks (`AiTicketAgentService`).
+- Restricted categories are excluded from automatic AI replies (`AiTicketAgentService`).
+- Fallback generation paths are used when AI output is unavailable/invalid.
+
+## Release Checklist
+
+- [x] Backup script uses SQLite snapshot backup semantics (`scripts/backup-helpdesk.sh`).
+- [x] Outbound email retry behavior performs one attempt per dispatch cycle and dead-letters once on terminal failure.
+- [x] Analytics dashboard queries avoid redundant ranged/open ticket materialization and per-ticket first-response subqueries.
+- [x] Unit and integration test suites pass.
+- [x] Build passes with warnings treated as errors.
+
+## Known Limitations and Mitigations
+
+- Limitation: SQLite remains a single-file datastore and may become a throughput bottleneck at higher sustained concurrency.
+  Mitigation: Keep frequent verified backups and monitor queue depth/latency; migrate to a server-grade database for scale-out.
+
+- Limitation: AI suggestions rely on model output quality and can degrade with poor prompt/data quality.
+  Mitigation: Continue technician approval workflows for non-low-risk responses and monitor AI audit events.
+
+- Limitation: Attachment malware scanning is not included in MVP.
+  Mitigation: Restrict content types and file sizes, and run upstream gateway scanning in production environments.

--- a/scripts/backup-helpdesk.sh
+++ b/scripts/backup-helpdesk.sh
@@ -76,7 +76,7 @@ if [[ "$INTEGRITY_RESULT" != "ok" ]]; then
   exit 1
 fi
 
-cp "$DB_PATH" "$PAYLOAD_DIR/helpdesk.db"
+sqlite3 "$DB_PATH" ".backup '$PAYLOAD_DIR/helpdesk.db'"
 
 if [[ -d "$ATTACHMENTS_PATH" ]]; then
   cp -R "$ATTACHMENTS_PATH" "$PAYLOAD_DIR/attachments"

--- a/src/Helpdesk.Light.Infrastructure/Services/KnowledgeBaseService.cs
+++ b/src/Helpdesk.Light.Infrastructure/Services/KnowledgeBaseService.cs
@@ -54,10 +54,11 @@ public sealed class KnowledgeBaseService : IKnowledgeBaseService
 
         if (!string.IsNullOrWhiteSpace(request.Search))
         {
-            string search = request.Search.Trim();
+            string search = EscapeLikePattern(request.Search.Trim());
+            string pattern = $"%{search}%";
             query = query.Where(item =>
-                EF.Functions.Like(item.Title, $"%{search}%") ||
-                EF.Functions.Like(item.ContentMarkdown, $"%{search}%"));
+                EF.Functions.Like(item.Title, pattern, "\\") ||
+                EF.Functions.Like(item.ContentMarkdown, pattern, "\\"));
         }
 
         int take = Math.Clamp(request.Take, 1, 300);
@@ -335,6 +336,15 @@ public sealed class KnowledgeBaseService : IKnowledgeBaseService
                 ## Prevention
                 - Capture recurring indicators and update monitoring thresholds for early detection.
                 """;
+    }
+
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal)
+            .Replace("[", "\\[", StringComparison.Ordinal);
     }
 
     private static KnowledgeArticleSummaryDto ToSummary(KnowledgeArticle article)

--- a/tests/Helpdesk.Light.UnitTests/AnalyticsServiceTests.cs
+++ b/tests/Helpdesk.Light.UnitTests/AnalyticsServiceTests.cs
@@ -1,0 +1,141 @@
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Domain.Entities;
+using Helpdesk.Light.Domain.Security;
+using Helpdesk.Light.Domain.Tickets;
+using Helpdesk.Light.Infrastructure.Data;
+using Helpdesk.Light.Infrastructure.Identity;
+using Helpdesk.Light.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Helpdesk.Light.UnitTests;
+
+public sealed class AnalyticsServiceTests
+{
+    [Fact]
+    public async Task GetDashboardAsync_ComputesExpectedRangeAndFirstResponseMetrics()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        await using HelpdeskDbContext dbContext = CreateDbContext(connection);
+
+        Guid customerId = SeedDataConstants.ContosoCustomerId;
+        Guid endUserId = Guid.NewGuid();
+
+        dbContext.Customers.Add(new Customer(customerId, "Contoso"));
+        dbContext.Users.Add(new ApplicationUser
+        {
+            Id = endUserId,
+            UserName = "enduser@contoso.com",
+            NormalizedUserName = "ENDUSER@CONTOSO.COM",
+            Email = "enduser@contoso.com",
+            NormalizedEmail = "ENDUSER@CONTOSO.COM",
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            DisplayName = "Contoso End User",
+            CustomerId = customerId
+        });
+
+        DateTime ticketOneCreatedUtc = new(2026, 02, 10, 10, 00, 00, DateTimeKind.Utc);
+        DateTime ticketTwoCreatedUtc = ticketOneCreatedUtc.AddMinutes(30);
+
+        Ticket ticketOne = new(
+            Guid.NewGuid(),
+            customerId,
+            endUserId,
+            TicketChannel.Email,
+            "Mail outage",
+            "Inbound mail is delayed.",
+            TicketPriority.High,
+            ticketOneCreatedUtc);
+
+        Ticket ticketTwo = new(
+            Guid.NewGuid(),
+            customerId,
+            endUserId,
+            TicketChannel.Web,
+            "Portal issue",
+            "Ticket portal page fails to load.",
+            TicketPriority.Low,
+            ticketTwoCreatedUtc);
+
+        ticketTwo.TransitionStatus(TicketStatus.Resolved, ticketTwoCreatedUtc.AddMinutes(45));
+
+        dbContext.Tickets.AddRange(ticketOne, ticketTwo);
+
+        dbContext.TicketMessages.AddRange(
+            new TicketMessage(
+                Guid.NewGuid(),
+                ticketOne.Id,
+                TicketAuthorType.EndUser,
+                endUserId,
+                "Initial report",
+                TicketMessageSource.Web,
+                null,
+                ticketOneCreatedUtc.AddMinutes(2)),
+            new TicketMessage(
+                Guid.NewGuid(),
+                ticketOne.Id,
+                TicketAuthorType.Technician,
+                Guid.NewGuid(),
+                "Acknowledged and investigating",
+                TicketMessageSource.Web,
+                null,
+                ticketOneCreatedUtc.AddMinutes(8)),
+            new TicketMessage(
+                Guid.NewGuid(),
+                ticketTwo.Id,
+                TicketAuthorType.Agent,
+                null,
+                "Automated first response",
+                TicketMessageSource.Ai,
+                null,
+                ticketTwoCreatedUtc.AddMinutes(10)));
+
+        await dbContext.SaveChangesAsync();
+
+        TestTenantContextAccessor tenantContext = new(new TenantAccessContext(
+            Guid.NewGuid(),
+            "admin@msp.local",
+            RoleNames.MspAdmin,
+            null));
+
+        AnalyticsService service = new(dbContext, tenantContext);
+
+        AnalyticsDashboardDto dashboard = await service.GetDashboardAsync(new AnalyticsDashboardRequest(
+            customerId,
+            ticketOneCreatedUtc.AddHours(-1),
+            ticketTwoCreatedUtc.AddHours(2)));
+
+        Assert.Equal(2, dashboard.TotalTicketVolume);
+        Assert.Equal(1, dashboard.OpenTicketCount);
+        Assert.Equal(1, dashboard.OpenTicketsByPriority[TicketPriority.High.ToString()]);
+        Assert.Equal(0, dashboard.OpenTicketsByPriority[TicketPriority.Low.ToString()]);
+        Assert.Equal(1, dashboard.ChannelSplit[TicketChannel.Email.ToString()]);
+        Assert.Equal(1, dashboard.ChannelSplit[TicketChannel.Web.ToString()]);
+        Assert.NotNull(dashboard.AverageFirstResponseMinutes);
+        Assert.Equal(9d, dashboard.AverageFirstResponseMinutes!.Value, 3);
+    }
+
+    private static async Task<SqliteConnection> OpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    private static HelpdeskDbContext CreateDbContext(SqliteConnection connection)
+    {
+        DbContextOptions<HelpdeskDbContext> options = new DbContextOptionsBuilder<HelpdeskDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        HelpdeskDbContext dbContext = new(options);
+        dbContext.Database.EnsureCreated();
+        return dbContext;
+    }
+
+    private sealed class TestTenantContextAccessor(TenantAccessContext context) : ITenantContextAccessor
+    {
+        public TenantAccessContext Current => context;
+    }
+}

--- a/tests/Helpdesk.Light.UnitTests/BackupScriptTests.cs
+++ b/tests/Helpdesk.Light.UnitTests/BackupScriptTests.cs
@@ -1,0 +1,34 @@
+namespace Helpdesk.Light.UnitTests;
+
+public sealed class BackupScriptTests
+{
+    [Fact]
+    public void BackupScript_UsesSqliteBackupCommandInsteadOfRawCopy()
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        string scriptPath = Path.Combine(repositoryRoot, "scripts", "backup-helpdesk.sh");
+
+        Assert.True(File.Exists(scriptPath), $"Expected backup script at '{scriptPath}'.");
+
+        string script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("sqlite3 \"$DB_PATH\" \".backup '$PAYLOAD_DIR/helpdesk.db'\"", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("cp \"$DB_PATH\" \"$PAYLOAD_DIR/helpdesk.db\"", script, StringComparison.Ordinal);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Helpdesk.Light.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root from test execution path.");
+    }
+}

--- a/tests/Helpdesk.Light.UnitTests/KnowledgeBaseServiceSearchTests.cs
+++ b/tests/Helpdesk.Light.UnitTests/KnowledgeBaseServiceSearchTests.cs
@@ -1,0 +1,145 @@
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Application.Contracts.Ai;
+using Helpdesk.Light.Domain.Ai;
+using Helpdesk.Light.Domain.Security;
+using Helpdesk.Light.Infrastructure.Data;
+using Helpdesk.Light.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Helpdesk.Light.UnitTests;
+
+public sealed class KnowledgeBaseServiceSearchTests
+{
+    [Fact]
+    public async Task ListAsync_SearchTreatsPercentAndUnderscoreAsLiteralCharacters()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        await using HelpdeskDbContext dbContext = CreateDbContext(connection);
+
+        Guid customerId = SeedDataConstants.ContosoCustomerId;
+        Guid editorId = Guid.NewGuid();
+        DateTime utcNow = DateTime.UtcNow;
+
+        KnowledgeArticle percentArticle = new(
+            Guid.NewGuid(),
+            customerId,
+            null,
+            "CPU at 100% usage",
+            "Escalation note",
+            aiGenerated: false,
+            editedByUserId: editorId,
+            createdUtc: utcNow);
+
+        KnowledgeArticle underscoreArticle = new(
+            Guid.NewGuid(),
+            customerId,
+            null,
+            "Queue_delay troubleshooting",
+            "Escalation note",
+            aiGenerated: false,
+            editedByUserId: editorId,
+            createdUtc: utcNow.AddMinutes(1));
+
+        KnowledgeArticle normalArticle = new(
+            Guid.NewGuid(),
+            customerId,
+            null,
+            "General troubleshooting guide",
+            "Escalation note",
+            aiGenerated: false,
+            editedByUserId: editorId,
+            createdUtc: utcNow.AddMinutes(2));
+
+        dbContext.KnowledgeArticles.AddRange(percentArticle, underscoreArticle, normalArticle);
+        await dbContext.SaveChangesAsync();
+
+        TestTenantContextAccessor tenantContext = new(new TenantAccessContext(
+            editorId,
+            "tech@contoso.com",
+            RoleNames.Technician,
+            customerId));
+
+        KnowledgeBaseService service = new(
+            dbContext,
+            tenantContext,
+            new StubPlatformSettingsService(),
+            NullLogger<KnowledgeBaseService>.Instance);
+
+        IReadOnlyList<KnowledgeArticleSummaryDto> percentResults = await service.ListAsync(
+            new KnowledgeArticleListRequest("%", null, customerId, 50));
+
+        Assert.Contains(percentResults, item => item.Id == percentArticle.Id);
+        Assert.DoesNotContain(percentResults, item => item.Id == underscoreArticle.Id);
+        Assert.DoesNotContain(percentResults, item => item.Id == normalArticle.Id);
+
+        IReadOnlyList<KnowledgeArticleSummaryDto> underscoreResults = await service.ListAsync(
+            new KnowledgeArticleListRequest("_", null, customerId, 50));
+
+        Assert.Contains(underscoreResults, item => item.Id == underscoreArticle.Id);
+        Assert.DoesNotContain(underscoreResults, item => item.Id == percentArticle.Id);
+        Assert.DoesNotContain(underscoreResults, item => item.Id == normalArticle.Id);
+    }
+
+    private static async Task<SqliteConnection> OpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    private static HelpdeskDbContext CreateDbContext(SqliteConnection connection)
+    {
+        DbContextOptions<HelpdeskDbContext> options = new DbContextOptionsBuilder<HelpdeskDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        HelpdeskDbContext dbContext = new(options);
+        dbContext.Database.EnsureCreated();
+        return dbContext;
+    }
+
+    private sealed class TestTenantContextAccessor(TenantAccessContext context) : ITenantContextAccessor
+    {
+        public TenantAccessContext Current => context;
+    }
+
+    private sealed class StubPlatformSettingsService : IPlatformSettingsService
+    {
+        public Task<PlatformSettingsDto> GetAdminSettingsAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<PlatformSettingsDto> UpdateAdminSettingsAsync(
+            PlatformSettingsUpdateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<RuntimePlatformSettings> GetRuntimeSettingsAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new RuntimePlatformSettings(
+                EnableAi: false,
+                ModelId: "gpt-5-mini",
+                OpenAIApiKey: null,
+                EmailTransportMode: EmailTransportModes.Console,
+                Smtp: new RuntimeSmtpSettings(
+                    Host: string.Empty,
+                    Port: 587,
+                    UseSsl: true,
+                    Username: string.Empty,
+                    Password: string.Empty,
+                    FromAddress: "noreply@example.com",
+                    FromDisplayName: "Helpdesk"),
+                Graph: new RuntimeGraphEmailSettings(
+                    TenantId: string.Empty,
+                    ClientId: string.Empty,
+                    ClientSecret: string.Empty,
+                    SenderUserId: string.Empty)));
+        }
+    }
+}

--- a/tests/Helpdesk.Light.UnitTests/OutboundEmailServiceTests.cs
+++ b/tests/Helpdesk.Light.UnitTests/OutboundEmailServiceTests.cs
@@ -1,0 +1,242 @@
+using Helpdesk.Light.Application.Abstractions;
+using Helpdesk.Light.Application.Abstractions.Email;
+using Helpdesk.Light.Application.Contracts;
+using Helpdesk.Light.Domain.Email;
+using Helpdesk.Light.Domain.Security;
+using Helpdesk.Light.Infrastructure.Data;
+using Helpdesk.Light.Infrastructure.Options;
+using Helpdesk.Light.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Helpdesk.Light.UnitTests;
+
+public sealed class OutboundEmailServiceTests
+{
+    [Fact]
+    public async Task DispatchPendingAsync_WhenTransportFails_AttemptsOnlyOncePerRun()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        await using HelpdeskDbContext dbContext = CreateDbContext(connection);
+
+        OutboundEmailMessage message = new(
+            Guid.NewGuid(),
+            null,
+            SeedDataConstants.ContosoCustomerId,
+            "enduser@contoso.com",
+            "Retry once",
+            "Body",
+            $"retry-once:{Guid.NewGuid():N}",
+            DateTime.UtcNow);
+
+        dbContext.OutboundEmailMessages.Add(message);
+        await dbContext.SaveChangesAsync();
+
+        FailingEmailTransport transport = new();
+        TestRuntimeMetricsRecorder metrics = new();
+        OutboundEmailService service = CreateService(dbContext, transport, metrics, maxRetryCount: 3);
+
+        await service.DispatchPendingAsync();
+
+        OutboundEmailMessage persisted = await dbContext.OutboundEmailMessages.SingleAsync(item => item.Id == message.Id);
+        int deadLetterEvents = await dbContext.AuditEvents.CountAsync(item => item.EventType == "email.dead_lettered");
+
+        Assert.Equal(1, transport.SendCount);
+        Assert.Equal(1, persisted.AttemptCount);
+        Assert.Equal(OutboundEmailStatus.Failed, persisted.Status);
+        Assert.Equal(1, metrics.EmailFailedCount);
+        Assert.Equal(0, metrics.EmailDeadLetterCount);
+        Assert.Equal(0, deadLetterEvents);
+    }
+
+    [Fact]
+    public async Task DispatchPendingAsync_WhenFinalAttemptFails_MarksDeadLetterOnce()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        await using HelpdeskDbContext dbContext = CreateDbContext(connection);
+
+        OutboundEmailMessage message = new(
+            Guid.NewGuid(),
+            null,
+            SeedDataConstants.ContosoCustomerId,
+            "enduser@contoso.com",
+            "Final attempt",
+            "Body",
+            $"final-attempt:{Guid.NewGuid():N}",
+            DateTime.UtcNow);
+
+        message.MarkAttempt();
+        message.MarkFailure("smtp timeout #1");
+        message.MarkAttempt();
+        message.MarkFailure("smtp timeout #2");
+
+        dbContext.OutboundEmailMessages.Add(message);
+        await dbContext.SaveChangesAsync();
+
+        FailingEmailTransport transport = new();
+        TestRuntimeMetricsRecorder metrics = new();
+        OutboundEmailService service = CreateService(dbContext, transport, metrics, maxRetryCount: 3);
+
+        await service.DispatchPendingAsync();
+
+        OutboundEmailMessage persisted = await dbContext.OutboundEmailMessages.SingleAsync(item => item.Id == message.Id);
+        int deadLetterEvents = await dbContext.AuditEvents.CountAsync(item => item.EventType == "email.dead_lettered");
+
+        Assert.Equal(1, transport.SendCount);
+        Assert.Equal(3, persisted.AttemptCount);
+        Assert.Equal(OutboundEmailStatus.DeadLetter, persisted.Status);
+        Assert.Equal(1, metrics.EmailDeadLetterCount);
+        Assert.Equal(1, deadLetterEvents);
+    }
+
+    [Fact]
+    public async Task DispatchPendingAsync_WhenRetryBudgetAlreadySpent_DoesNotSendAgain()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        await using HelpdeskDbContext dbContext = CreateDbContext(connection);
+
+        OutboundEmailMessage message = new(
+            Guid.NewGuid(),
+            null,
+            SeedDataConstants.ContosoCustomerId,
+            "enduser@contoso.com",
+            "Already exhausted",
+            "Body",
+            $"already-exhausted:{Guid.NewGuid():N}",
+            DateTime.UtcNow);
+
+        message.MarkAttempt();
+        message.MarkFailure("smtp timeout #1");
+        message.MarkAttempt();
+        message.MarkFailure("smtp timeout #2");
+        message.MarkAttempt();
+        message.MarkFailure("smtp timeout #3");
+
+        dbContext.OutboundEmailMessages.Add(message);
+        await dbContext.SaveChangesAsync();
+
+        FailingEmailTransport transport = new();
+        TestRuntimeMetricsRecorder metrics = new();
+        OutboundEmailService service = CreateService(dbContext, transport, metrics, maxRetryCount: 3);
+
+        await service.DispatchPendingAsync();
+
+        OutboundEmailMessage persisted = await dbContext.OutboundEmailMessages.SingleAsync(item => item.Id == message.Id);
+        int deadLetterEvents = await dbContext.AuditEvents.CountAsync(item => item.EventType == "email.dead_lettered");
+
+        Assert.Equal(0, transport.SendCount);
+        Assert.Equal(3, persisted.AttemptCount);
+        Assert.Equal(OutboundEmailStatus.DeadLetter, persisted.Status);
+        Assert.Equal(1, metrics.EmailDeadLetterCount);
+        Assert.Equal(1, deadLetterEvents);
+    }
+
+    private static OutboundEmailService CreateService(
+        HelpdeskDbContext dbContext,
+        IEmailTransport transport,
+        IRuntimeMetricsRecorder metrics,
+        int maxRetryCount)
+    {
+        TestTenantContextAccessor tenantContext = new(new TenantAccessContext(
+            Guid.NewGuid(),
+            "admin@msp.local",
+            RoleNames.MspAdmin,
+            null));
+
+        return new OutboundEmailService(
+            dbContext,
+            transport,
+            tenantContext,
+            metrics,
+            Options.Create(new EmailOptions { MaxRetryCount = maxRetryCount }));
+    }
+
+    private static async Task<SqliteConnection> OpenConnectionAsync()
+    {
+        SqliteConnection connection = new("Data Source=:memory:");
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    private static HelpdeskDbContext CreateDbContext(SqliteConnection connection)
+    {
+        DbContextOptions<HelpdeskDbContext> options = new DbContextOptionsBuilder<HelpdeskDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        HelpdeskDbContext dbContext = new(options);
+        dbContext.Database.EnsureCreated();
+        return dbContext;
+    }
+
+    private sealed class FailingEmailTransport : IEmailTransport
+    {
+        public int SendCount { get; private set; }
+
+        public Task SendAsync(string toAddress, string subject, string body, CancellationToken cancellationToken = default)
+        {
+            SendCount += 1;
+            throw new InvalidOperationException("smtp transport unavailable");
+        }
+    }
+
+    private sealed class TestTenantContextAccessor(TenantAccessContext context) : ITenantContextAccessor
+    {
+        public TenantAccessContext Current => context;
+    }
+
+    private sealed class TestRuntimeMetricsRecorder : IRuntimeMetricsRecorder
+    {
+        public int EmailFailedCount { get; private set; }
+
+        public int EmailDeadLetterCount { get; private set; }
+
+        public void RecordApiRequest(int statusCode, double latencyMs)
+        {
+        }
+
+        public void SetWorkerQueueDepth(int depth)
+        {
+        }
+
+        public void RecordEmailSent()
+        {
+        }
+
+        public void RecordEmailFailed()
+        {
+            EmailFailedCount += 1;
+        }
+
+        public void RecordEmailDeadLetter()
+        {
+            EmailDeadLetterCount += 1;
+        }
+
+        public void RecordAiRun(double durationMs, bool success)
+        {
+        }
+
+        public void RecordWorkerFailure(string worker, string error)
+        {
+        }
+
+        public OperationsMetricsDto GetSnapshot()
+        {
+            return new OperationsMetricsDto(
+                DateTime.UtcNow,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                []);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves all currently open repository issues: `#21`, `#27`, `#28`, `#29`, `#30`, `#31`, and `#32`.

The previous implementation had four concrete reliability/performance gaps and one release-readiness documentation gap:

- outbound email dispatch consumed multiple retries in a single worker cycle and duplicated dead-letter transitions,
- analytics dashboard executed redundant ticket materialization and per-ticket first-response query logic,
- knowledge-base search treated `%` and `_` as unescaped LIKE wildcards,
- backup scripting copied a live SQLite file directly instead of using a transactional SQLite backup snapshot,
- release hardening and known limitations were not documented as a single tracked checklist.

## Root Cause and User Impact

Outbound email retry handling used an inner loop that exhausted retry budget immediately under transient provider failures, reducing recovery opportunities between worker cycles and inflating risk of premature dead-lettering. The same method had two dead-letter paths, which could duplicate audit/metric side effects.

Analytics dashboard calculations materialized similar ticket sets multiple times and used a projection pattern for first response that risked inefficient query plans as data volume grows.

Knowledge article search assembled LIKE patterns without escaping user-entered wildcard characters. This produced broad, unintended matches when users searched for literal `%` or `_` characters.

Backup logic performed raw file copy against a potentially active SQLite database. Under concurrent writes, this can produce an inconsistent backup image.

## What Changed

### 1) Outbound email reliability

- Refactored `OutboundEmailService.DispatchPendingAsync` to perform exactly one send attempt per message per dispatch run.
- Consolidated dead-letter transitions into a single helper path (`MarkDeadLetter`) to prevent duplicate dead-letter events.
- Preserved send-failure audit recording and terminal dead-lettering when the final allowed attempt fails.

### 2) Analytics query efficiency

- Refactored `AnalyticsService.GetDashboardAsync` to materialize ranged tickets once into a lightweight projection.
- Reused that projection for total/open/channel calculations.
- Replaced per-ticket first-response subquery pattern with a grouped ticket-message query and dictionary lookup for first-response timestamps.

### 3) Knowledge-base search hardening

- Added LIKE-pattern escaping in `KnowledgeBaseService` for `\\`, `%`, `_`, and `[`.
- Switched search filter to `EF.Functions.Like(..., pattern, "\\")` so wildcard characters are interpreted literally when escaped.

### 4) Backup safety

- Updated `scripts/backup-helpdesk.sh` to use SQLite snapshot backup:
  - `sqlite3 "$DB_PATH" ".backup '$PAYLOAD_DIR/helpdesk.db'"`

### 5) Release hardening documentation

- Added `docs/release-readiness-security.md` with:
  - authorization/tenant isolation coverage references,
  - sanitization and attachment safeguards,
  - AI guardrail notes,
  - MVP release checklist,
  - known limitations and mitigation notes.
- Added README link to the new checklist document.

### 6) Added regression/unit tests

- `OutboundEmailServiceTests`:
  - one-attempt-per-dispatch on failure,
  - single dead-letter transition at terminal failure,
  - no send attempt when retry budget is already exhausted.
- `AnalyticsServiceTests`:
  - validates expected volume/open/channel and average first-response output from seeded data.
- `KnowledgeBaseServiceSearchTests`:
  - verifies `%` and `_` are treated as literals in search.
- `BackupScriptTests`:
  - verifies backup script uses SQLite `.backup` and no longer uses raw DB `cp`.

## Validation

Executed locally on this branch:

- `dotnet restore Helpdesk.Light.slnx`
- `dotnet build Helpdesk.Light.slnx -warnaserror`
- `dotnet test Helpdesk.Light.slnx`

Results:

- Build succeeded with `0 Warning(s)` and `0 Error(s)`.
- Unit tests: `29 passed`, `0 failed`.
- Integration tests: `35 passed`, `0 failed`.

## Additional Included Files

This branch also includes the previously untracked GitHub workflow files in `.github/workflows/` (`ci.yml` and `release.yml`) so the repository state is consistent with the new README CI/CD references.

Closes #21
Closes #27
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
